### PR TITLE
remove invalid exception when no plugins are found

### DIFF
--- a/include/pluginlib/class_loader_imp.h
+++ b/include/pluginlib/class_loader_imp.h
@@ -180,11 +180,6 @@ namespace pluginlib
     //Pull possible files from manifests of packages which depend on this package and export class
     std::vector<std::string> paths;
     ros::package::getPlugins(package, attrib_name, paths);
-    if (paths.size() == 0)
-    {
-      std::string error_string = "rospack could not find the " + package_ + " package containing " +  base_class_;
-      throw LibraryLoadException(error_string);
-    }
     return paths;
   }
 


### PR DESCRIPTION
E.g. when running the nodelet manager but no nodelets are there it raises an exception.

It  looks like this regression was introduces in this refactoring: https://github.com/ros/pluginlib/commit/0ce6b4744101fb1379b07709a0f6b082e49c7873#diff-4a232a6b10422dba01b32b3bb76b933bR182

Before there was no exception then the result list was just empty.
