### PR TITLE
Add ":" to split function within getName.

### DIFF
--- a/include/pluginlib/class_loader_imp.h
+++ b/include/pluginlib/class_loader_imp.h
@@ -385,7 +385,7 @@ namespace pluginlib
   {
     //remove the package name to get the raw plugin name
     std::vector<std::string> split;
-    boost::split(split, lookup_name, boost::is_any_of("/"));
+    boost::split(split, lookup_name, boost::is_any_of("/:"));
     return split.back();
   }
 


### PR DESCRIPTION
getName split wasn't supporting `::` as the delimiter for the package name and
the plugin name.
