### PR TITLE
Fix wrong package name test

### DIFF
--- a/include/pluginlib/class_loader.h
+++ b/include/pluginlib/class_loader.h
@@ -62,7 +62,7 @@ namespace pluginlib
          * @param base_class The type of the base class for classes to be loaded
          * @param attrib_name The attribute to search for in manifext.xml files, defaults to "plugin"
          * @param plugin_xml_paths The list of paths of plugin.xml files, defaults to be crawled via ros::package::getPlugins()
-         * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
+         * @exception pluginlib::ClassLoaderException Thrown if package manifest cannot be found
          */
         ClassLoader(std::string package, std::string base_class, std::string attrib_name = std::string("plugin"), std::vector<std::string> plugin_xml_paths = std::vector<std::string>());
 

--- a/include/pluginlib/class_loader_imp.h
+++ b/include/pluginlib/class_loader_imp.h
@@ -59,6 +59,11 @@ namespace pluginlib
   /***************************************************************************/
   {
     ROS_DEBUG_NAMED("pluginlib.ClassLoader","Creating ClassLoader, base = %s, address = %p", base_class.c_str(), this);
+    if (ros::package::getPath(package_).empty())
+    {
+      throw pluginlib::ClassLoaderException("Unable to find package: " + package_);
+    }
+
     if (plugin_xml_paths_.size() == 0)
     {
       plugin_xml_paths_ = getPluginXmlPaths(package_, attrib_name_);

--- a/include/pluginlib/pluginlib_exceptions.h
+++ b/include/pluginlib/pluginlib_exceptions.h
@@ -56,6 +56,16 @@ class LibraryLoadException: public PluginlibException
 };
 
 /**
+ * @class ClassLoaderException
+ * @brief An exception class thrown when pluginlib is unable to instantiate a class loader
+ */
+class ClassLoaderException: public PluginlibException
+{
+  public:
+    ClassLoaderException(const std::string error_desc) : PluginlibException(error_desc) {}
+};
+
+/**
  * @class LibraryUnloadException
  * @brief An exception class thrown when pluginlib is unable to unload the library associated with a given plugin
  */

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -55,7 +55,7 @@ TEST(PluginlibTest, invalidPackage)
   {
     pluginlib::ClassLoader<test_base::Fubar> bad_test_loader("pluginlib_bad", "test_base::Fubar");
   }
-  catch(pluginlib::LibraryLoadException& ex)
+  catch(pluginlib::ClassLoaderException& ex)
   {
     SUCCEED();
     return;


### PR DESCRIPTION
Throw an exception if ClassLoader can't be instantiated due to an invalid package name

Fixes #31 
