### PR TITLE
Remove Boost Software License from license tag

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,6 @@
   </description>
   <maintainer email="esteve@osrfoundation.org">Esteve Fernandez</maintainer>
   <license>BSD</license>
-  <license>Boost Software License</license>
 
   <url>http://www.ros.org/wiki/pluginlib</url>
   <author>Eitan Marder-Eppstein</author>


### PR DESCRIPTION
The Boost Software License was only in there for Poco, as can be seen in
6e0659f. As Poco was removed in 44ab6fb and all remaining Files have a
BSD header, let's remove the Boost tag as well, to be consistent.
