### PR TITLE
Enable on demand unloading

### DIFF
--- a/include/pluginlib/class_loader_imp.h
+++ b/include/pluginlib/class_loader_imp.h
@@ -55,7 +55,7 @@ namespace pluginlib
   package_(package),
   base_class_(base_class),
   attrib_name_(attrib_name),
-  lowlevel_class_loader_(false) //NOTE: The parameter to the class loader enables/disables on-demand class loading/unloading. Leaving it off for now...libraries will be loaded immediately and won't be unloaded until class loader is destroyed or force unload.
+  lowlevel_class_loader_(true) // Enable on-demand class loading/unloading
   /***************************************************************************/
   {
     ROS_DEBUG_NAMED("pluginlib.ClassLoader","Creating ClassLoader, base = %s, address = %p", base_class.c_str(), this);


### PR DESCRIPTION
Fixes #37, `issue1.cpp`. Relates to #38, which is fixed by https://github.com/ros/class_loader/pull/34.
