### PR TITLE
Throw exception if plugin.xml is broken

### DIFF
--- a/include/pluginlib/class_loader_imp.h
+++ b/include/pluginlib/class_loader_imp.h
@@ -599,8 +599,19 @@ namespace pluginlib
       TiXmlElement* class_element = library->FirstChildElement("class");
       while (class_element)
       {
-        std::string base_class_type = class_element->Attribute("base_class_type");
-        std::string derived_class = class_element->Attribute("type");
+        std::string derived_class;
+        if (class_element->Attribute("type") != NULL) {
+          derived_class = std::string(class_element->Attribute("type"));
+        } else {
+          throw pluginlib::ClassLoaderException("Class could not be loaded. Attribute 'type' in class tag is missing.");
+        }
+
+        std::string base_class_type;
+        if (class_element->Attribute("base_class_type") != NULL) {
+          base_class_type = std::string(class_element->Attribute("base_class_type"));
+        } else {
+          throw pluginlib::ClassLoaderException("Class could not be loaded. Attribute 'base_class_type' in class tag is missing.");
+        }
 
         std::string lookup_name;
         if(class_element->Attribute("name") != NULL)

--- a/package.xml
+++ b/package.xml
@@ -33,5 +33,6 @@
 
   <export>
     <pluginlib plugin="${prefix}/test/test_plugins.xml"/>
+    <pluginlib plugin_test="${prefix}/test/test_plugins_broken.xml"/>
   </export>
 </package>

--- a/test/test_plugins_broken.xml
+++ b/test/test_plugins_broken.xml
@@ -1,0 +1,5 @@
+<library path="lib/libtest_plugins">
+  <class name="pluginlib/foo" name="test_plugins::Foo" base_class_type="test_base::Fubar">
+    <description>This is a foo plugin.</description>
+  </class>
+</library>

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -184,12 +184,8 @@ TEST(PluginlibTest, brokenXML)
     SUCCEED();
     return;
   }
-  //catch(...)
-  //{
-  //  FAIL() << "Uncaught exception";
-  //}
-  ADD_FAILURE() << "Didn't throw exception as expected";
 
+  ADD_FAILURE() << "Didn't throw exception as expected";
 }
 
 // Run all the tests that were declared with TEST()

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -24,7 +24,6 @@ TEST(PluginlibTest, unknownPlugin)
  
 }
 
-
 TEST(PluginlibTest, misspelledPlugin)
 {
   pluginlib::ClassLoader<test_base::Fubar> bad_test_loader("pluginlib", "test_base::Fuba");
@@ -172,6 +171,25 @@ TEST(PluginlibTest, createManagedInstanceAndUnloadLibrary)
     FAIL() << "Could not unload library when I should be able to.";
   }
   ROS_INFO( "Done." );
+}
+
+TEST(PluginlibTest, brokenXML)
+{
+  try
+  {
+    pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar", "plugin_test");
+  }
+  catch(pluginlib::ClassLoaderException& ex)
+  {
+    SUCCEED();
+    return;
+  }
+  //catch(...)
+  //{
+  //  FAIL() << "Uncaught exception";
+  //}
+  ADD_FAILURE() << "Didn't throw exception as expected";
+
 }
 
 // Run all the tests that were declared with TEST()


### PR DESCRIPTION
I stumbled recently over an "basic_string::_M_construct null not valid" error using pluginlib. After about an hour of searching I found the problem: an attribute of an class tag was missing. I've created a test case to reproduce this error and now exceptions are thrown if required attributes of the class-tag are missing.
