### PR TITLE
Style overhaul

### DIFF
--- a/include/pluginlib/class_desc.h
+++ b/include/pluginlib/class_desc.h
@@ -38,43 +38,47 @@
 
 #include <string>
 
-namespace pluginlib {
+namespace pluginlib
+{
+/**
+ * @class ClassDesc
+ * @brief Storage for information about a given class
+ */
+class ClassDesc
+{
+public:
   /**
-   * @class ClassDesc
-   * @brief Storage for information about a given class
+   * @brief  Constructor for a ClassDesc
+   * @param lookup_name The lookup name of the class
+   * @param derived_class The type of the derived class of the class
+   * @param base_class The type of the class, corresponds to the type of the base class
+   * @param package The package the class lives in
+   * @param description A description for the class
+   * @param library_name The name of the containing library for the class (not a full path!)
+   * @param plugin_manifest_path The path to the plugin manifest file
    */
-  class ClassDesc
-  {
-    public:
-      /**
-       * @brief  Constructor for a ClassDesc
-       * @param lookup_name The lookup name of the class
-       * @param derived_class The type of the derived class of the class
-       * @param base_class The type of the class, corresponds to the type of the base class
-       * @param package The package the class lives in
-       * @param description A description for the class
-       * @param library_name The name of the containing library for the class (not a full path!)
-       * @param plugin_manifest_path The path to the plugin manifest file
-       */
-      ClassDesc(const std::string& lookup_name, const std::string& derived_class, const std::string& base_class, const std::string& package,
-          const std::string& description, const std::string& library_name, const std::string& plugin_manifest_path):
-        lookup_name_(lookup_name),
-        derived_class_(derived_class),
-        base_class_(base_class),
-        package_(package),
-        description_(description),
-        library_name_(library_name),
-        resolved_library_path_("UNRESOLVED"),
-        plugin_manifest_path_(plugin_manifest_path){}
+  ClassDesc(
+    const std::string & lookup_name, const std::string & derived_class,
+    const std::string & base_class, const std::string & package,
+    const std::string & description, const std::string & library_name,
+    const std::string & plugin_manifest_path)
+  : lookup_name_(lookup_name),
+    derived_class_(derived_class),
+    base_class_(base_class),
+    package_(package),
+    description_(description),
+    library_name_(library_name),
+    resolved_library_path_("UNRESOLVED"),
+    plugin_manifest_path_(plugin_manifest_path) {}
 
-      std::string lookup_name_;
-      std::string derived_class_;
-      std::string base_class_;
-      std::string package_;
-      std::string description_;
-      std::string library_name_;
-      std::string resolved_library_path_; //This is set by pluginlib::ClassLoader at load time
-      std::string plugin_manifest_path_;
-  };
+  std::string lookup_name_;
+  std::string derived_class_;
+  std::string base_class_;
+  std::string package_;
+  std::string description_;
+  std::string library_name_;
+  std::string resolved_library_path_;     //This is set by pluginlib::ClassLoader at load time
+  std::string plugin_manifest_path_;
 };
+}
 #endif

--- a/include/pluginlib/class_desc.h
+++ b/include/pluginlib/class_desc.h
@@ -33,22 +33,20 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *
 *********************************************************************/
-#ifndef PLUGINLIB_CLASS_DESC_H_
-#define PLUGINLIB_CLASS_DESC_H_
+
+#ifndef PLUGINLIB__CLASS_DESC_H_
+#define PLUGINLIB__CLASS_DESC_H_
 
 #include <string>
 
 namespace pluginlib
 {
-/**
- * @class ClassDesc
- * @brief Storage for information about a given class
- */
+
+/// Storage for information about a given class.
 class ClassDesc
 {
 public:
   /**
-   * @brief  Constructor for a ClassDesc
    * @param lookup_name The lookup name of the class
    * @param derived_class The type of the derived class of the class
    * @param base_class The type of the class, corresponds to the type of the base class
@@ -77,8 +75,10 @@ public:
   std::string package_;
   std::string description_;
   std::string library_name_;
-  std::string resolved_library_path_;     //This is set by pluginlib::ClassLoader at load time
+  std::string resolved_library_path_;  // This is set by pluginlib::ClassLoader at load time.
   std::string plugin_manifest_path_;
 };
-}
-#endif
+
+}  // namespace pluginlib
+
+#endif  // PLUGINLIB__CLASS_DESC_H_

--- a/include/pluginlib/class_list_macros.h
+++ b/include/pluginlib/class_list_macros.h
@@ -34,8 +34,8 @@
 *
 *********************************************************************/
 
-#ifndef PLUGINLIB_CLASS_LIST_MACROS_H_
-#define PLUGINLIB_CLASS_LIST_MACROS_H_
+#ifndef PLUGINLIB__CLASS_LIST_MACROS_H_
+#define PLUGINLIB__CLASS_LIST_MACROS_H_
 
 #include <class_loader/class_loader.h>
 
@@ -66,4 +66,4 @@
 #define PLUGINLIB_EXPORT_CLASS(class_type, base_class_type) \
   CLASS_LOADER_REGISTER_CLASS(class_type, base_class_type);
 
-#endif
+#endif  // PLUGINLIB__CLASS_LIST_MACROS_H_

--- a/include/pluginlib/class_loader.h
+++ b/include/pluginlib/class_loader.h
@@ -47,269 +47,281 @@ namespace pluginlib
 {
 
 #if __cplusplus >= 201103L
-  template<typename T>
-  using UniquePtr = class_loader::ClassLoader::UniquePtr<T>;
+template<typename T>
+using UniquePtr = class_loader::ClassLoader::UniquePtr<T>;
 #endif
+/**
+ * @class ClassLoader
+ * @brief A class to help manage and load classes
+ */
+template<class T>
+class ClassLoader : public ClassLoaderBase
+{
+public:
+  typedef typename std::map<std::string, ClassDesc>::iterator ClassMapIterator;
+
+public:
   /**
-   * @class ClassLoader
-   * @brief A class to help manage and load classes
+   * @brief  Constructor for a ClassLoader
+   * @param package The package containing the base class
+   * @param base_class The type of the base class for classes to be loaded
+   * @param attrib_name The attribute to search for in manifext.xml files, defaults to "plugin"
+   * @param plugin_xml_paths The list of paths of plugin.xml files, defaults to be crawled via ros::package::getPlugins()
+   * @exception pluginlib::ClassLoaderException Thrown if package manifest cannot be found
    */
-  template <class T>
-    class ClassLoader: public ClassLoaderBase
-    {
-      public:
-        typedef typename std::map<std::string, ClassDesc>::iterator ClassMapIterator;
+  ClassLoader(
+    std::string package, std::string base_class,
+    std::string attrib_name = std::string("plugin"),
+    std::vector<std::string> plugin_xml_paths = std::vector<std::string>());
 
-      public:
-        /**
-         * @brief  Constructor for a ClassLoader
-         * @param package The package containing the base class
-         * @param base_class The type of the base class for classes to be loaded
-         * @param attrib_name The attribute to search for in manifext.xml files, defaults to "plugin"
-         * @param plugin_xml_paths The list of paths of plugin.xml files, defaults to be crawled via ros::package::getPlugins()
-         * @exception pluginlib::ClassLoaderException Thrown if package manifest cannot be found
-         */
-        ClassLoader(std::string package, std::string base_class, std::string attrib_name = std::string("plugin"), std::vector<std::string> plugin_xml_paths = std::vector<std::string>());
+  /**
+   * @brief  Destructor for ClassLoader
+   */
+  ~ClassLoader();
 
-        /**
-         * @brief  Destructor for ClassLoader
-         */
-        ~ClassLoader();
+  /**
+   * @brief  Creates an instance of a desired class, optionally loading the associated library automatically if necessary
+   * @param  lookup_name The name of the class to load
+   * @param  auto_load Specifies whether or not to automatically load the library containing the class, set to true by default
+   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
+   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * @return An instance of the class
+   * @deprecated use either createInstance() or createUnmanagedInstance().
+   */
+  __attribute__((deprecated)) T * createClassInstance(
+    const std::string & lookup_name,
+    bool auto_load = true);
 
-        /**
-         * @brief  Creates an instance of a desired class, optionally loading the associated library automatically if necessary
-         * @param  lookup_name The name of the class to load
-         * @param  auto_load Specifies whether or not to automatically load the library containing the class, set to true by default
-         * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-         * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
-         * @return An instance of the class
-         * @deprecated use either createInstance() or createUnmanagedInstance().
-         */
-        __attribute__((deprecated)) T* createClassInstance(const std::string& lookup_name, bool auto_load = true);
-
-        /**
-         * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
-         * Deleting the instance and calling unloadLibraryForClass() is automatically handled by the shared pointer.
-         * @param  lookup_name The name of the class to load
-         * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-         * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
-         * @return An instance of the class
-         */
-        boost::shared_ptr<T> createInstance(const std::string& lookup_name);
+  /**
+   * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
+   * Deleting the instance and calling unloadLibraryForClass() is automatically handled by the shared pointer.
+   * @param  lookup_name The name of the class to load
+   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
+   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * @return An instance of the class
+   */
+  boost::shared_ptr<T> createInstance(const std::string & lookup_name);
 
 #if __cplusplus >= 201103L
-        /**
-         * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
-         * Deleting the instance and calling unloadLibraryForClass() is automatically handled by the unique pointer.
-         *
-         * If you release the wrapped pointer you must manually call the original deleter when you want to destroy the released pointer.
-         *
-         * @param  lookup_name The name of the class to load
-         * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-         * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
-         * @return An instance of the class
-         */
-        UniquePtr<T> createUniqueInstance(const std::string& lookup_name);
+  /**
+   * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
+   * Deleting the instance and calling unloadLibraryForClass() is automatically handled by the unique pointer.
+   *
+   * If you release the wrapped pointer you must manually call the original deleter when you want to destroy the released pointer.
+   *
+   * @param  lookup_name The name of the class to load
+   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
+   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * @return An instance of the class
+   */
+  UniquePtr<T> createUniqueInstance(const std::string & lookup_name);
 #endif
 
-        /**
-         * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
-         * @attention The ownership is transfered to the caller, which is responsible for deleting the instance and calling unloadLibraryForClass()
-         * (in order to decrement the associated library counter and unloading it if it is no more used).
-         * @param  lookup_name The name of the class to load
-         * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-         * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
-         * @return An instance of the class
-         */
-        T* createUnmanagedInstance(const std::string& lookup_name);
+  /**
+   * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
+   * @attention The ownership is transfered to the caller, which is responsible for deleting the instance and calling unloadLibraryForClass()
+   * (in order to decrement the associated library counter and unloading it if it is no more used).
+   * @param  lookup_name The name of the class to load
+   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
+   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * @return An instance of the class
+   */
+  T * createUnmanagedInstance(const std::string & lookup_name);
 
-        /**
-         * @brief  Returns a list of all available plugin manifest paths for this ClassLoader's base class type
-         * @return A vector of strings corresponding to the paths of all available plugin manifests
-         */
-        std::vector<std::string> getPluginXmlPaths();
+  /**
+   * @brief  Returns a list of all available plugin manifest paths for this ClassLoader's base class type
+   * @return A vector of strings corresponding to the paths of all available plugin manifests
+   */
+  std::vector<std::string> getPluginXmlPaths();
 
-        /**
-         * @brief  Returns a list of all available classes for this ClassLoader's base class type
-         * @return A vector of strings corresponding to the names of all available classes
-         */
-        std::vector<std::string> getDeclaredClasses();
+  /**
+   * @brief  Returns a list of all available classes for this ClassLoader's base class type
+   * @return A vector of strings corresponding to the names of all available classes
+   */
+  std::vector<std::string> getDeclaredClasses();
 
-        /**
-         * @brief  Strips the package name off of a lookup name
-         * @param lookup_name The name of the plugin
-         * @return The name of the plugin stripped of the package name
-         */
-        virtual std::string getName(const std::string& lookup_name);
+  /**
+   * @brief  Strips the package name off of a lookup name
+   * @param lookup_name The name of the plugin
+   * @return The name of the plugin stripped of the package name
+   */
+  virtual std::string getName(const std::string & lookup_name);
 
-        /**
-         * @brief  Given the lookup name of a class, returns the type of the associated base class
-         * @return The type of the associated base class
-         */
-        virtual std::string getBaseClassType() const;
+  /**
+   * @brief  Given the lookup name of a class, returns the type of the associated base class
+   * @return The type of the associated base class
+   */
+  virtual std::string getBaseClassType() const;
 
-        /**
-         * @brief  Given the lookup name of a class, returns the type of the derived class associated with it
-         * @param lookup_name The name of the class
-         * @return The name of the associated derived class
-         */
-        virtual std::string getClassType(const std::string& lookup_name);
+  /**
+   * @brief  Given the lookup name of a class, returns the type of the derived class associated with it
+   * @param lookup_name The name of the class
+   * @return The name of the associated derived class
+   */
+  virtual std::string getClassType(const std::string & lookup_name);
 
-        /**
-         * @brief  Given the lookup name of a class, returns its description
-         * @param lookup_name The lookup name of the class
-         * @return The description of the class
-         */
-        virtual std::string getClassDescription(const std::string& lookup_name);
+  /**
+   * @brief  Given the lookup name of a class, returns its description
+   * @param lookup_name The lookup name of the class
+   * @return The description of the class
+   */
+  virtual std::string getClassDescription(const std::string & lookup_name);
 
-        /**
-         * @brief  Given the name of a class, returns the path to its associated library
-         * @param lookup_name The name of the class
-         * @return The path to the associated library
-         */
-        virtual std::string getClassLibraryPath(const std::string& lookup_name);
+  /**
+   * @brief  Given the name of a class, returns the path to its associated library
+   * @param lookup_name The name of the class
+   * @return The path to the associated library
+   */
+  virtual std::string getClassLibraryPath(const std::string & lookup_name);
 
-        /**
-         * @brief  Given the name of a class, returns name of the containing package
-         * @param lookup_name The name of the class
-         * @return The name of the containing package
-         */
-        virtual std::string getClassPackage(const std::string& lookup_name);
+  /**
+   * @brief  Given the name of a class, returns name of the containing package
+   * @param lookup_name The name of the class
+   * @return The name of the containing package
+   */
+  virtual std::string getClassPackage(const std::string & lookup_name);
 
-        /**
-         * @brief  Given the name of a class, returns the path of the associated plugin manifest
-         * @param lookup_name The name of the class
-         * @return The path of the associated plugin manifest
-         */
-        virtual std::string getPluginManifestPath(const std::string& lookup_name);
+  /**
+   * @brief  Given the name of a class, returns the path of the associated plugin manifest
+   * @param lookup_name The name of the class
+   * @return The path of the associated plugin manifest
+   */
+  virtual std::string getPluginManifestPath(const std::string & lookup_name);
 
-        /**
-         * @brief  Returns the libraries that are registered and can be loaded
-         * @return A vector of strings corresponding to the names of registered libraries
-         */
-        virtual std::vector<std::string> getRegisteredLibraries();
+  /**
+   * @brief  Returns the libraries that are registered and can be loaded
+   * @return A vector of strings corresponding to the names of registered libraries
+   */
+  virtual std::vector<std::string> getRegisteredLibraries();
 
-        /**
-         * @brief Checks if the library for a given class is currently loaded
-         * @param  lookup_name The lookup name of the class to query
-         * @return True if the class is loaded, false otherwise
-         */
-        bool isClassLoaded(const std::string& lookup_name);
+  /**
+   * @brief Checks if the library for a given class is currently loaded
+   * @param  lookup_name The lookup name of the class to query
+   * @return True if the class is loaded, false otherwise
+   */
+  bool isClassLoaded(const std::string & lookup_name);
 
-        /**
-         * @brief  Checks if the class associated with a plugin name is available to be loaded
-         * @param lookup_name The name of the plugin
-         * @return True if the plugin is available, false otherwise
-         */
-        virtual bool isClassAvailable(const std::string& lookup_name);
+  /**
+   * @brief  Checks if the class associated with a plugin name is available to be loaded
+   * @param lookup_name The name of the plugin
+   * @return True if the plugin is available, false otherwise
+   */
+  virtual bool isClassAvailable(const std::string & lookup_name);
 
-        /**
-         * @brief  Attempts to load the library containing a class with a given name and increments a counter for the library
-         * @param lookup_name The lookup name of the class to load
-         * @exception pluginlib::LibraryLoadException Thrown if the library for the class cannot be loaded
-         */
-        virtual void loadLibraryForClass(const std::string & lookup_name);
+  /**
+   * @brief  Attempts to load the library containing a class with a given name and increments a counter for the library
+   * @param lookup_name The lookup name of the class to load
+   * @exception pluginlib::LibraryLoadException Thrown if the library for the class cannot be loaded
+   */
+  virtual void loadLibraryForClass(const std::string & lookup_name);
 
-        /**
-         * @brief  Refreshs the list of all available classes for this ClassLoader's base class type
-         * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
-         */
-        virtual void refreshDeclaredClasses();
+  /**
+   * @brief  Refreshs the list of all available classes for this ClassLoader's base class type
+   * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
+   */
+  virtual void refreshDeclaredClasses();
 
-        /**
-         * @brief  Decrements the counter for the library containing a class with a given name and attempts to unload it if the counter reaches zero
-         * @param lookup_name The lookup name of the class to unload
-         * @exception pluginlib::LibraryUnloadException Thrown if the library for the class cannot be unloaded
-         * @return The number of pending unloads until the library is removed from memory
-         */
-        virtual int unloadLibraryForClass(const std::string& lookup_name);
+  /**
+   * @brief  Decrements the counter for the library containing a class with a given name and attempts to unload it if the counter reaches zero
+   * @param lookup_name The lookup name of the class to unload
+   * @exception pluginlib::LibraryUnloadException Thrown if the library for the class cannot be unloaded
+   * @return The number of pending unloads until the library is removed from memory
+   */
+  virtual int unloadLibraryForClass(const std::string & lookup_name);
 
-      private:
+private:
+  /**
+   * Returns the paths to plugin.xml files.
+   * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
+   * @return A vector of paths
+   */
+  std::vector<std::string> getPluginXmlPaths(
+    const std::string & package,
+    const std::string & attrib_name,
+    bool force_recrawl = false);
 
-        /**
-         * Returns the paths to plugin.xml files.
-         * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
-         * @return A vector of paths
-         */
-        std::vector<std::string> getPluginXmlPaths(const std::string& package, const std::string& attrib_name, bool force_recrawl=false);
+  /**
+   * @brief  Returns the available classes
+   * @param plugin_xml_paths The vector of paths of plugin.xml files
+   * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
+   * @return A map of class names and the corresponding descriptions
+   */
+  std::map<std::string, ClassDesc> determineAvailableClasses(
+    const std::vector<std::string> & plugin_xml_paths);
 
-        /**
-         * @brief  Returns the available classes
-         * @param plugin_xml_paths The vector of paths of plugin.xml files
-         * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
-         * @return A map of class names and the corresponding descriptions
-         */
-        std::map<std::string, ClassDesc> determineAvailableClasses(const std::vector<std::string>& plugin_xml_paths);
+  /**
+  * Opens a package.xml file and extracts the package name (i.e. contents of <name> tag)
+  */
+  std::string extractPackageNameFromPackageXML(const std::string & package_xml_path);
 
-        /**
-        * Opens a package.xml file and extracts the package name (i.e. contents of <name> tag)
-        */
-        std::string extractPackageNameFromPackageXML(const std::string& package_xml_path);
+  /**
+   * Gets a list of paths to try to find a library. As we transition from rosbuild to Catkin build systems, plugins can be found in the old rosbuild place (pkg_name/lib usually) or somewhere in the Catkin build space
+   */
+  std::vector<std::string> getAllLibraryPathsToTry(
+    const std::string & library_name,
+    const std::string & exporting_package_name);
 
-        /**
-         * Gets a list of paths to try to find a library. As we transition from rosbuild to Catkin build systems, plugins can be found in the old rosbuild place (pkg_name/lib usually) or somewhere in the Catkin build space
-         */
-        std::vector<std::string> getAllLibraryPathsToTry(const std::string& library_name, const std::string& exporting_package_name);
+  /**
+   * Returns the paths where libraries are installed according to the Catkin build system.
+   */
+  std::vector<std::string> getCatkinLibraryPaths();
 
-        /**
-         * Returns the paths where libraries are installed according to the Catkin build system.
-         */
-        std::vector<std::string> getCatkinLibraryPaths();
+  /**
+   * @brief  Returns an error message for an unknown class
+   * @param lookup_name The name of the class
+   * @return The error message
+   */
+  std::string getErrorStringForUnknownClass(const std::string & lookup_name);
 
-        /**
-         * @brief  Returns an error message for an unknown class
-         * @param lookup_name The name of the class
-         * @return The error message
-         */
-        std::string getErrorStringForUnknownClass(const std::string& lookup_name);
+  /**
+   * Gets the standard path separator for the native OS (e.g. "/" on *nix, "\" on windows)
+   */
+  std::string getPathSeparator();
 
-        /**
-         * Gets the standard path separator for the native OS (e.g. "/" on *nix, "\" on windows)
-         */
-        std::string getPathSeparator();
+  /**
+   * Gets the path where rosbuild build system thinks plugins are installed
+   */
+  std::string getROSBuildLibraryPath(const std::string & exporting_package_name);
 
-        /**
-         * Gets the path where rosbuild build system thinks plugins are installed
-         */
-        std::string getROSBuildLibraryPath(const std::string& exporting_package_name);
+  /**
+  * Gets the package name from a path to a plugin XML file
+  */
+  std::string getPackageFromPluginXMLFilePath(const std::string & path);
 
-        /**
-        * Gets the package name from a path to a plugin XML file
-        */
-        std::string getPackageFromPluginXMLFilePath(const std::string & path);
+  /**
+  * Joins two filesystem paths together utilzing appropriate path separator
+  */
+  std::string joinPaths(const std::string & path1, const std::string & path2);
 
-        /**
-        * Joins two filesystem paths together utilzing appropriate path separator
-        */
-        std::string joinPaths(const std::string& path1, const std::string& path2);
+  /**
+   * Parses a plugin XML file and inserts the appropriate ClassDesc entries into the passes classes_available map
+   */
+  void processSingleXMLPluginFile(
+    const std::string & xml_file, std::map<std::string,
+    ClassDesc> & class_available);
 
-        /**
-         * Parses a plugin XML file and inserts the appropriate ClassDesc entries into the passes classes_available map
-         */
-        void processSingleXMLPluginFile(const std::string& xml_file, std::map<std::string, ClassDesc>& class_available);
-
-        /**
-         * Strips all but the filename from an explicit file path.
-         */
-        std::string stripAllButFileFromPath(const std::string& path);
+  /**
+   * Strips all but the filename from an explicit file path.
+   */
+  std::string stripAllButFileFromPath(const std::string & path);
 
 
-        /**
-         * @brief  Helper function for unloading a shared library
-         * @param  library_path The exact path to the library to unload
-         * @return The number of pending unloads until the library is removed from memory
-         */
-        int unloadClassLibraryInternal(const std::string& library_path);
+  /**
+   * @brief  Helper function for unloading a shared library
+   * @param  library_path The exact path to the library to unload
+   * @return The number of pending unloads until the library is removed from memory
+   */
+  int unloadClassLibraryInternal(const std::string & library_path);
 
-     private:
-        std::vector<std::string> plugin_xml_paths_;
-        std::map<std::string, ClassDesc> classes_available_; //Map from library to class's descriptions described in XML
-        std::string package_;
-        std::string base_class_;
-        std::string attrib_name_;
-        class_loader::MultiLibraryClassLoader lowlevel_class_loader_; //The underlying classloader
-    };
+private:
+  std::vector<std::string> plugin_xml_paths_;
+  std::map<std::string, ClassDesc> classes_available_;       //Map from library to class's descriptions described in XML
+  std::string package_;
+  std::string base_class_;
+  std::string attrib_name_;
+  class_loader::MultiLibraryClassLoader lowlevel_class_loader_;       //The underlying classloader
 };
+}
 
 #include "class_loader_imp.h" //Note: The implementation of the methods is in a separate file for clarity
 

--- a/include/pluginlib/class_loader.h
+++ b/include/pluginlib/class_loader.h
@@ -26,22 +26,28 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef PLUGINLIB_CLASS_LOADER_H
-#define PLUGINLIB_CLASS_LOADER_H
+
+#ifndef PLUGINLIB__CLASS_LOADER_H_
+#define PLUGINLIB__CLASS_LOADER_H_
+
+#include <map>
+#include <string>
+#include <vector>
 
 #include "boost/algorithm/string.hpp"
 #include "class_loader/multi_library_class_loader.h"
-#include <map>
 #include "pluginlib/class_desc.h"
 #include "pluginlib/class_loader_base.h"
 #include "pluginlib/pluginlib_exceptions.h"
 #include "ros/console.h"
 #include "ros/package.h"
-#include "tinyxml2.h"
+#include "tinyxml2.h"  // NOLINT
 
-//Note: pluginlib has traditionally utilized a "lookup name" for classes that does not match its real C++ name. This was
-//done due to limitations of how pluginlib was implemented. As of version 1.9, a lookup name is no longer necessary and
-//an attempt to the merge two concepts is underway
+// Note: pluginlib has traditionally utilized a "lookup name" for classes that does not match its
+// real C++ name.
+// This was done due to limitations of how pluginlib was implemented.
+// As of version 1.9, a lookup name is no longer necessary and an attempt to the merge two concepts
+// is underway.
 
 namespace pluginlib
 {
@@ -50,10 +56,7 @@ namespace pluginlib
 template<typename T>
 using UniquePtr = class_loader::ClassLoader::UniquePtr<T>;
 #endif
-/**
- * @class ClassLoader
- * @brief A class to help manage and load classes
- */
+/// A class to help manage and load classes.
 template<class T>
 class ClassLoader : public ClassLoaderBase
 {
@@ -62,11 +65,11 @@ public:
 
 public:
   /**
-   * @brief  Constructor for a ClassLoader
    * @param package The package containing the base class
    * @param base_class The type of the base class for classes to be loaded
    * @param attrib_name The attribute to search for in manifext.xml files, defaults to "plugin"
-   * @param plugin_xml_paths The list of paths of plugin.xml files, defaults to be crawled via ros::package::getPlugins()
+   * @param plugin_xml_paths The list of paths of plugin.xml files, defaults to be crawled via
+   *   ros::package::getPlugins()
    * @exception pluginlib::ClassLoaderException Thrown if package manifest cannot be found
    */
   ClassLoader(
@@ -74,17 +77,17 @@ public:
     std::string attrib_name = std::string("plugin"),
     std::vector<std::string> plugin_xml_paths = std::vector<std::string>());
 
-  /**
-   * @brief  Destructor for ClassLoader
-   */
   ~ClassLoader();
 
+  /// Creates an instance of a desired class, optionally loading the associated library too.
   /**
-   * @brief  Creates an instance of a desired class, optionally loading the associated library automatically if necessary
-   * @param  lookup_name The name of the class to load
-   * @param  auto_load Specifies whether or not to automatically load the library containing the class, set to true by default
-   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * @param lookup_name The name of the class to load
+   * @param auto_load Specifies whether or not to automatically load the
+   *   library containing the class, set to true by default.
+   * @exception pluginlib::LibraryLoadException Thrown when the library
+   *   associated with the class cannot be loaded
+   * @exception pluginlib::CreateClassException Thrown when the class cannot be
+   *   instantiated
    * @return An instance of the class
    * @deprecated use either createInstance() or createUnmanagedInstance().
    */
@@ -92,44 +95,61 @@ public:
     const std::string & lookup_name,
     bool auto_load = true);
 
+  /// Creates an instance of a desired class.
   /**
-   * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
-   * Deleting the instance and calling unloadLibraryForClass() is automatically handled by the shared pointer.
-   * @param  lookup_name The name of the class to load
-   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * Implicitly calls loadLibraryForClass() to increment the library counter.
+   *
+   * Deleting the instance and calling unloadLibraryForClass() is automatically
+   * handled by the shared pointer.
+   * @param lookup_name The name of the class to load
+   * @exception pluginlib::LibraryLoadException Thrown when the library
+   *   associated with the class cannot be loaded.
+   * @exception pluginlib::CreateClassException Thrown when the class cannot be
+   *   instantiated.
    * @return An instance of the class
    */
   boost::shared_ptr<T> createInstance(const std::string & lookup_name);
 
 #if __cplusplus >= 201103L
+  /// Creates an instance of a desired class.
   /**
-   * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
-   * Deleting the instance and calling unloadLibraryForClass() is automatically handled by the unique pointer.
+   * Implicitly calls loadLibraryForClass() to increment the library counter.
    *
-   * If you release the wrapped pointer you must manually call the original deleter when you want to destroy the released pointer.
+   * Deleting the instance and calling unloadLibraryForClass() is automatically
+   * handled by the unique pointer.
    *
-   * @param  lookup_name The name of the class to load
-   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * If you release the wrapped pointer you must manually call the original
+   * deleter when you want to destroy the released pointer.
+   *
+   * @param lookup_name The name of the class to load.
+   * @exception pluginlib::LibraryLoadException Thrown when the library
+   *   associated with the class cannot be loaded.
+   * @exception pluginlib::CreateClassException Thrown when the class cannot
+   *   be instantiated.
    * @return An instance of the class
    */
   UniquePtr<T> createUniqueInstance(const std::string & lookup_name);
 #endif
 
+  /// Creates an instance of a desired class.
   /**
-   * @brief  Creates an instance of a desired class (which implicitly calls loadLibraryForClass() to increment the library counter).
-   * @attention The ownership is transfered to the caller, which is responsible for deleting the instance and calling unloadLibraryForClass()
-   * (in order to decrement the associated library counter and unloading it if it is no more used).
-   * @param  lookup_name The name of the class to load
-   * @exception pluginlib::LibraryLoadException Thrown when the library associated with the class cannot be loaded
-   * @exception pluginlib::CreateClassException Thrown when the class cannot be instantiated
+   * Implicitly calls loadLibraryForClass() to increment the library counter.
+   *
+   * @attention The ownership is transfered to the caller, which is responsible
+   *   for deleting the instance and calling unloadLibraryForClass()
+   *   (in order to decrement the associated library counter and unloading it
+   *   if it is no more used).
+   * @param lookup_name The name of the class to load
+   * @exception pluginlib::LibraryLoadException Thrown when the library
+   *   associated with the class cannot be loaded
+   * @exception pluginlib::CreateClassException Thrown when the class cannot
+   *   be instantiated
    * @return An instance of the class
    */
   T * createUnmanagedInstance(const std::string & lookup_name);
 
+  /// Returns a list of all available plugin manifest paths for this ClassLoader's base class type.
   /**
-   * @brief  Returns a list of all available plugin manifest paths for this ClassLoader's base class type
    * @return A vector of strings corresponding to the paths of all available plugin manifests
    */
   std::vector<std::string> getPluginXmlPaths();
@@ -153,15 +173,15 @@ public:
    */
   virtual std::string getBaseClassType() const;
 
+  /// Given the lookup name of a class, returns the type of the derived class associated with it.
   /**
-   * @brief  Given the lookup name of a class, returns the type of the derived class associated with it
    * @param lookup_name The name of the class
    * @return The name of the associated derived class
    */
   virtual std::string getClassType(const std::string & lookup_name);
 
+  /// Given the lookup name of a class, returns its description.
   /**
-   * @brief  Given the lookup name of a class, returns its description
    * @param lookup_name The lookup name of the class
    * @return The description of the class
    */
@@ -208,10 +228,13 @@ public:
    */
   virtual bool isClassAvailable(const std::string & lookup_name);
 
+  /// Attempt to load the library containing a class with a given name.
   /**
-   * @brief  Attempts to load the library containing a class with a given name and increments a counter for the library
+   * The counter for the library uses (refcount) is also incremented.
+   *
    * @param lookup_name The lookup name of the class to load
-   * @exception pluginlib::LibraryLoadException Thrown if the library for the class cannot be loaded
+   * @exception pluginlib::LibraryLoadException Thrown if the library for the
+   *   class cannot be loaded
    */
   virtual void loadLibraryForClass(const std::string & lookup_name);
 
@@ -221,17 +244,20 @@ public:
    */
   virtual void refreshDeclaredClasses();
 
+  /// Decrement the counter for the library containing a class with a given name.
   /**
-   * @brief  Decrements the counter for the library containing a class with a given name and attempts to unload it if the counter reaches zero
+   * Also try to unload the library, If the counter reaches zero.
+   *
    * @param lookup_name The lookup name of the class to unload
-   * @exception pluginlib::LibraryUnloadException Thrown if the library for the class cannot be unloaded
+   * @exception pluginlib::LibraryUnloadException Thrown if the library for the
+   *   class cannot be unloaded
    * @return The number of pending unloads until the library is removed from memory
    */
   virtual int unloadLibraryForClass(const std::string & lookup_name);
 
 private:
+  /// Return the paths to plugin.xml files.
   /**
-   * Returns the paths to plugin.xml files.
    * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
    * @return A vector of paths
    */
@@ -254,8 +280,11 @@ private:
   */
   std::string extractPackageNameFromPackageXML(const std::string & package_xml_path);
 
+  /// Gets a list of paths to try to find a library.
   /**
-   * Gets a list of paths to try to find a library. As we transition from rosbuild to Catkin build systems, plugins can be found in the old rosbuild place (pkg_name/lib usually) or somewhere in the Catkin build space
+   * As we transition from rosbuild to Catkin build systems, plugins can be
+   * found in the old rosbuild place (pkg_name/lib usually) or somewhere in the
+   * Catkin build space.
    */
   std::vector<std::string> getAllLibraryPathsToTry(
     const std::string & library_name,
@@ -293,8 +322,10 @@ private:
   */
   std::string joinPaths(const std::string & path1, const std::string & path2);
 
+  /// Parse a plugin XML file.
   /**
-   * Parses a plugin XML file and inserts the appropriate ClassDesc entries into the passes classes_available map
+   * Also insert the appropriate ClassDesc entries into the passes
+   * classes_available map.
    */
   void processSingleXMLPluginFile(
     const std::string & xml_file, std::map<std::string,
@@ -315,14 +346,17 @@ private:
 
 private:
   std::vector<std::string> plugin_xml_paths_;
-  std::map<std::string, ClassDesc> classes_available_;       //Map from library to class's descriptions described in XML
+  // Map from library to class's descriptions described in XML.
+  std::map<std::string, ClassDesc> classes_available_;
   std::string package_;
   std::string base_class_;
   std::string attrib_name_;
-  class_loader::MultiLibraryClassLoader lowlevel_class_loader_;       //The underlying classloader
+  class_loader::MultiLibraryClassLoader lowlevel_class_loader_;  // The underlying classloader
 };
-}
 
-#include "class_loader_imp.h" //Note: The implementation of the methods is in a separate file for clarity
+}  // namespace pluginlib
 
-#endif //PLUGINLIB_CLASS_LOADER_H
+// Note: The implementation of the methods is in a separate file for clarity.
+#include "class_loader_imp.h"  // NOLINT
+
+#endif  // PLUGINLIB__CLASS_LOADER_H_

--- a/include/pluginlib/class_loader_base.h
+++ b/include/pluginlib/class_loader_base.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PLUGINLIB_CLASS_LOADER_BASE_H
-#define PLUGINLIB_CLASS_LOADER_BASE_H
+#ifndef PLUGINLIB__CLASS_LOADER_BASE_H_
+#define PLUGINLIB__CLASS_LOADER_BASE_H_
 
 #include <vector>
 #include <string>
@@ -36,12 +36,12 @@
 namespace pluginlib
 {
 /**
-  * Pure virtual base class of pluginlib::ClassLoader which is not
-  * templated.  This allows the writing of non-templated manager code
-  * which can call all the administrative functions of ClassLoaders -
-  * everything except createClassInstance(), createInstance()
-  * and createUnmanagedInstance().
-  */
+ * Pure virtual base class of pluginlib::ClassLoader which is not
+ * templated.  This allows the writing of non-templated manager code
+ * which can call all the administrative functions of ClassLoaders -
+ * everything except createClassInstance(), createInstance()
+ * and createUnmanagedInstance().
+ */
 class ClassLoaderBase
 {
 public:
@@ -50,8 +50,8 @@ public:
    */
   virtual ~ClassLoaderBase() {}
 
+  /// Return a list of all available plugin manifest paths.
   /**
-   * @brief  Returns a list of all available plugin manifest paths for this ClassLoader's base class type
    * @return A vector of strings corresponding to the paths of all available plugin manifests
    */
   virtual std::vector<std::string> getPluginXmlPaths() = 0;
@@ -82,8 +82,8 @@ public:
    */
   virtual bool isClassAvailable(const std::string & lookup_name) = 0;
 
+  /// Given the lookup name of a class, return the type of the derived class associated with it.
   /**
-   * @brief  Given the lookup name of a class, returns the type of the derived class associated with it
    * @param lookup_name The name of the class
    * @return The name of the associated derived class
    */
@@ -126,14 +126,16 @@ public:
   /**
    * @brief  Attempts to load a class with a given name
    * @param lookup_name The lookup name of the class to load
-   * @exception pluginlib::LibraryLoadException Thrown if the library for the class cannot be loaded
+   * @exception pluginlib::LibraryLoadException Thrown if the library for the
+   *   class cannot be loaded
    */
   virtual void loadLibraryForClass(const std::string & lookup_name) = 0;
 
   /**
    * @brief  Attempts to unload a class with a given name
    * @param lookup_name The lookup name of the class to unload
-   * @exception pluginlib::LibraryUnloadException Thrown if the library for the class cannot be unloaded
+   * @exception pluginlib::LibraryUnloadException Thrown if the library for the
+   *   class cannot be unloaded
    * @return The number of pending unloads until the library is removed from memory
    */
   virtual int unloadLibraryForClass(const std::string & lookup_name) = 0;
@@ -151,6 +153,6 @@ public:
    */
   virtual std::string getClassLibraryPath(const std::string & lookup_name) = 0;
 };
-}
+}  // namespace pluginlib
 
-#endif
+#endif  // PLUGINLIB__CLASS_LOADER_BASE_H_

--- a/include/pluginlib/class_loader_base.h
+++ b/include/pluginlib/class_loader_base.h
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright (c) 2012, Willow Garage, Inc.
  * All rights reserved.
  *
@@ -35,122 +35,122 @@
 
 namespace pluginlib
 {
- /**
-   * Pure virtual base class of pluginlib::ClassLoader which is not
-   * templated.  This allows the writing of non-templated manager code
-   * which can call all the administrative functions of ClassLoaders -
-   * everything except createClassInstance(), createInstance()
-   * and createUnmanagedInstance().
+/**
+  * Pure virtual base class of pluginlib::ClassLoader which is not
+  * templated.  This allows the writing of non-templated manager code
+  * which can call all the administrative functions of ClassLoaders -
+  * everything except createClassInstance(), createInstance()
+  * and createUnmanagedInstance().
+  */
+class ClassLoaderBase
+{
+public:
+  /**
+   * @brief Empty virtual destructor
    */
-  class ClassLoaderBase
-  {
-    public:
-      /**
-       * @brief Empty virtual destructor
-       */
-      virtual ~ClassLoaderBase() {}
+  virtual ~ClassLoaderBase() {}
 
-      /**
-       * @brief  Returns a list of all available plugin manifest paths for this ClassLoader's base class type
-       * @return A vector of strings corresponding to the paths of all available plugin manifests
-       */
-      virtual std::vector<std::string> getPluginXmlPaths() = 0;
+  /**
+   * @brief  Returns a list of all available plugin manifest paths for this ClassLoader's base class type
+   * @return A vector of strings corresponding to the paths of all available plugin manifests
+   */
+  virtual std::vector<std::string> getPluginXmlPaths() = 0;
 
-      /**
-       * @brief  Returns a list of all available classes for this ClassLoader's base class type
-       * @return A vector of strings corresponding to the names of all available classes
-       */
-      virtual std::vector<std::string> getDeclaredClasses() = 0;
+  /**
+   * @brief  Returns a list of all available classes for this ClassLoader's base class type
+   * @return A vector of strings corresponding to the names of all available classes
+   */
+  virtual std::vector<std::string> getDeclaredClasses() = 0;
 
-      /**
-       * @brief  Refreshs the list of all available classes for this ClassLoader's base class type
-       * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
-       */
-      virtual void refreshDeclaredClasses() = 0;
+  /**
+   * @brief  Refreshs the list of all available classes for this ClassLoader's base class type
+   * @exception pluginlib::LibraryLoadException Thrown if package manifest cannot be found
+   */
+  virtual void refreshDeclaredClasses() = 0;
 
-      /**
-       * @brief  Strips the package name off of a lookup name
-       * @param lookup_name The name of the plugin
-       * @return The name of the plugin stripped of the package name
-       */
-      virtual std::string getName(const std::string& lookup_name) = 0;
+  /**
+   * @brief  Strips the package name off of a lookup name
+   * @param lookup_name The name of the plugin
+   * @return The name of the plugin stripped of the package name
+   */
+  virtual std::string getName(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Checks if the class associated with a plugin name is available to be loaded
-       * @param lookup_name The name of the plugin
-       * @return True if the plugin is available, false otherwise
-       */
-      virtual bool isClassAvailable(const std::string& lookup_name) = 0;
+  /**
+   * @brief  Checks if the class associated with a plugin name is available to be loaded
+   * @param lookup_name The name of the plugin
+   * @return True if the plugin is available, false otherwise
+   */
+  virtual bool isClassAvailable(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Given the lookup name of a class, returns the type of the derived class associated with it
-       * @param lookup_name The name of the class
-       * @return The name of the associated derived class
-       */
-      virtual std::string getClassType(const std::string& lookup_name) = 0;
+  /**
+   * @brief  Given the lookup name of a class, returns the type of the derived class associated with it
+   * @param lookup_name The name of the class
+   * @return The name of the associated derived class
+   */
+  virtual std::string getClassType(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Given the lookup name of a class, returns its description
-       * @param lookup_name The lookup name of the class
-       * @return The description of the class
-       */
-      virtual std::string getClassDescription(const std::string& lookup_name) = 0;
+  /**
+   * @brief  Given the lookup name of a class, returns its description
+   * @param lookup_name The lookup name of the class
+   * @return The description of the class
+   */
+  virtual std::string getClassDescription(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Given the lookup name of a class, returns the type of the associated base class
-       * @return The type of the associated base class
-       */
-      virtual std::string getBaseClassType() const = 0;
+  /**
+   * @brief  Given the lookup name of a class, returns the type of the associated base class
+   * @return The type of the associated base class
+   */
+  virtual std::string getBaseClassType() const = 0;
 
-      /**
-       * @brief  Given the name of a class, returns name of the containing package
-       * @param lookup_name The name of the class
-       * @return The name of the containing package
-       */
-      virtual std::string getClassPackage(const std::string& lookup_name) = 0;
+  /**
+   * @brief  Given the name of a class, returns name of the containing package
+   * @param lookup_name The name of the class
+   * @return The name of the containing package
+   */
+  virtual std::string getClassPackage(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Given the name of a class, returns the path of the associated plugin manifest
-       * @param lookup_name The name of the class
-       * @return The path of the associated plugin manifest
-       */
-      virtual std::string getPluginManifestPath(const std::string& lookup_name) = 0;
+  /**
+   * @brief  Given the name of a class, returns the path of the associated plugin manifest
+   * @param lookup_name The name of the class
+   * @return The path of the associated plugin manifest
+   */
+  virtual std::string getPluginManifestPath(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief Checks if a given class is currently loaded
-       * @param  lookup_name The lookup name of the class to query
-       * @return True if the class is loaded, false otherwise
-       */
-      virtual bool isClassLoaded(const std::string& lookup_name) = 0;
+  /**
+   * @brief Checks if a given class is currently loaded
+   * @param  lookup_name The lookup name of the class to query
+   * @return True if the class is loaded, false otherwise
+   */
+  virtual bool isClassLoaded(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Attempts to load a class with a given name
-       * @param lookup_name The lookup name of the class to load
-       * @exception pluginlib::LibraryLoadException Thrown if the library for the class cannot be loaded
-       */
-      virtual void loadLibraryForClass(const std::string & lookup_name) = 0;
+  /**
+   * @brief  Attempts to load a class with a given name
+   * @param lookup_name The lookup name of the class to load
+   * @exception pluginlib::LibraryLoadException Thrown if the library for the class cannot be loaded
+   */
+  virtual void loadLibraryForClass(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Attempts to unload a class with a given name
-       * @param lookup_name The lookup name of the class to unload
-       * @exception pluginlib::LibraryUnloadException Thrown if the library for the class cannot be unloaded
-       * @return The number of pending unloads until the library is removed from memory
-       */
-      virtual int unloadLibraryForClass(const std::string& lookup_name) = 0;
+  /**
+   * @brief  Attempts to unload a class with a given name
+   * @param lookup_name The lookup name of the class to unload
+   * @exception pluginlib::LibraryUnloadException Thrown if the library for the class cannot be unloaded
+   * @return The number of pending unloads until the library is removed from memory
+   */
+  virtual int unloadLibraryForClass(const std::string & lookup_name) = 0;
 
-      /**
-       * @brief  Returns the libraries that are registered and can be loaded
-       * @return A vector of strings corresponding to the names of registered libraries
-       */
-      virtual std::vector<std::string> getRegisteredLibraries() = 0;
+  /**
+   * @brief  Returns the libraries that are registered and can be loaded
+   * @return A vector of strings corresponding to the names of registered libraries
+   */
+  virtual std::vector<std::string> getRegisteredLibraries() = 0;
 
-      /**
-       * @brief  Given the name of a class, returns the path to its associated library
-       * @param lookup_name The name of the class
-       * @return The path to the associated library
-       */
-      virtual std::string getClassLibraryPath(const std::string& lookup_name) = 0;
-  };
+  /**
+   * @brief  Given the name of a class, returns the path to its associated library
+   * @param lookup_name The name of the class
+   * @return The path to the associated library
+   */
+  virtual std::string getClassLibraryPath(const std::string & lookup_name) = 0;
+};
 }
 
 #endif

--- a/include/pluginlib/class_loader_imp.h
+++ b/include/pluginlib/class_loader_imp.h
@@ -622,12 +622,11 @@ void ClassLoader<T>::loadLibraryForClass(const std::string & lookup_name)
     lowlevel_class_loader_.loadLibrary(library_path);
     it->second.resolved_library_path_ = library_path;
   } catch (const class_loader::LibraryLoadException & ex) {
-    std::string error_string = "Failed to load library " + library_path +
-      ". Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the "
+    std::string error_string =
+      "Failed to load library " + library_path + ". "
+      "Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the "
       "library code, and that names are consistent between this macro and your XML. "
-      "Error string: "
-      +
-      ex.what();
+      "Error string: " + ex.what();
     throw pluginlib::LibraryLoadException(error_string);
   }
 }

--- a/include/pluginlib/class_loader_imp.h
+++ b/include/pluginlib/class_loader_imp.h
@@ -58,9 +58,10 @@ const std::string os_pathsep(":");
 
 namespace
 {
-std::vector<std::string> catkinFindLib() {
+std::vector<std::string> catkinFindLib()
+{
   std::vector<std::string> lib_paths;
-  const char* env = std::getenv("CMAKE_PREFIX_PATH");
+  const char * env = std::getenv("CMAKE_PREFIX_PATH");
   if (env) {
     std::string env_catkin_prefix_paths(env);
     std::vector<std::string> catkin_prefix_paths;
@@ -78,664 +79,706 @@ std::vector<std::string> catkinFindLib() {
 
 namespace pluginlib
 {
-  template <class T>
-  ClassLoader<T>::ClassLoader(std::string package, std::string base_class, std::string attrib_name, std::vector<std::string> plugin_xml_paths) :
-  plugin_xml_paths_(plugin_xml_paths),
+template<class T>
+ClassLoader<T>::ClassLoader(
+  std::string package, std::string base_class, std::string attrib_name,
+  std::vector<std::string> plugin_xml_paths)
+: plugin_xml_paths_(plugin_xml_paths),
   package_(package),
   base_class_(base_class),
   attrib_name_(attrib_name),
   lowlevel_class_loader_(false) //NOTE: The parameter to the class loader enables/disables on-demand class loading/unloading. Leaving it off for now...libraries will be loaded immediately and won't be unloaded until class loader is destroyed or force unload.
   /***************************************************************************/
-  {
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Creating ClassLoader, base = %s, address = %p", base_class.c_str(), this);
-    if (ros::package::getPath(package_).empty())
-    {
-      throw pluginlib::ClassLoaderException("Unable to find package: " + package_);
-    }
-
-    if (plugin_xml_paths_.size() == 0)
-    {
-      plugin_xml_paths_ = getPluginXmlPaths(package_, attrib_name_);
-    }
-    classes_available_ = determineAvailableClasses(plugin_xml_paths_);
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Finished constructring ClassLoader, base = %s, address = %p", base_class.c_str(), this);
+{
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",
+    base_class.c_str(), this);
+  if (ros::package::getPath(package_).empty()) {
+    throw pluginlib::ClassLoaderException("Unable to find package: " + package_);
   }
 
-  template <class T>
-  ClassLoader<T>::~ClassLoader()
-  /***************************************************************************/
-  {
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Destroying ClassLoader, base = %s, address = %p", getBaseClassType().c_str(), this);
+  if (plugin_xml_paths_.size() == 0) {
+    plugin_xml_paths_ = getPluginXmlPaths(package_, attrib_name_);
   }
-
-
-  template <class T>
-  T* ClassLoader<T>::createClassInstance(const std::string& lookup_name, bool auto_load)
-  /***************************************************************************/
-  {
-    //Note: This method is deprecated
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","In deprecated call createClassInstance(), lookup_name = %s, auto_load = %i.", (lookup_name.c_str()), auto_load);
-
-    if (auto_load && !isClassLoaded(lookup_name))
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Autoloading class library before attempting to create instance.");
-      loadLibraryForClass(lookup_name);
-    }
-
-    try
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Attempting to create instance through low-level MultiLibraryClassLoader...");
-      T* obj = lowlevel_class_loader_.createUnmanagedInstance<T>(getClassType(lookup_name));
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Instance created with object pointer = %p", obj);
-
-      return obj;
-    }
-    catch (const class_loader::CreateClassException& ex)
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","CreateClassException about to be raised for class %s", lookup_name.c_str());
-      throw pluginlib::CreateClassException(ex.what());
-    }
-  }
-
-  template <class T>
-  boost::shared_ptr<T> ClassLoader<T>::createInstance(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Attempting to create managed instance for class %s.", lookup_name.c_str());
-
-    if (!isClassLoaded(lookup_name))
-      loadLibraryForClass(lookup_name);
-
-    try
-    {
-      std::string class_type = getClassType(lookup_name);
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","%s maps to real class type %s", lookup_name.c_str(), class_type.c_str());
-
-      boost::shared_ptr<T> obj = lowlevel_class_loader_.createInstance<T>(class_type);
-
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","boost::shared_ptr to object of real type %s created.", class_type.c_str());
-
-      return obj;
-    }
-    catch (const class_loader::CreateClassException& ex)
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Exception raised by low-level multi-library class loader when attempting to create instance of class %s.", lookup_name.c_str());
-      throw pluginlib::CreateClassException(ex.what());
-    }
-  }
-
-#if __cplusplus >= 201103L
-  template <class T>
-  UniquePtr<T> ClassLoader<T>::createUniqueInstance(const std::string& lookup_name)
-  {
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Attempting to create managed (unique) instance for class %s.", lookup_name.c_str());
-
-    if (!isClassLoaded(lookup_name))
-      loadLibraryForClass(lookup_name);
-
-    try
-    {
-      std::string class_type = getClassType(lookup_name);
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","%s maps to real class type %s", lookup_name.c_str(), class_type.c_str());
-
-      UniquePtr<T> obj = lowlevel_class_loader_.createUniqueInstance<T>(class_type);
-
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","std::unique_ptr to object of real type %s created.", class_type.c_str());
-
-      return obj;
-    }
-    catch (const class_loader::CreateClassException& ex)
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Exception raised by low-level multi-library class loader when attempting to create instance of class %s.", lookup_name.c_str());
-      throw pluginlib::CreateClassException(ex.what());
-    }
-
-  }
-#endif
-
-  template <class T>
-  T* ClassLoader<T>::createUnmanagedInstance(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Attempting to create UNMANAGED instance for class %s.", lookup_name.c_str());
-
-    if (!isClassLoaded(lookup_name))
-      loadLibraryForClass(lookup_name);
-
-    T* instance = 0;
-    try
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Attempting to create instance through low level multi-library class loader.");
-      std::string class_type = getClassType(lookup_name);
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","%s maps to real class type %s", lookup_name.c_str(), class_type.c_str());
-      instance = lowlevel_class_loader_.createUnmanagedInstance<T>(class_type);
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Instance of type %s created.", class_type.c_str());
-    }
-    catch (const class_loader::CreateClassException& ex) //mas - change exception type here (DONE)
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Exception raised by low-level multi-library class loader when attempting to create UNMANAGED instance of class %s.", lookup_name.c_str());
-      throw pluginlib::CreateClassException(ex.what());
-    }
-    return instance;
-  }
-
-  template <class T>
-  std::vector<std::string> ClassLoader<T>::getPluginXmlPaths(const std::string& package, const std::string& attrib_name, bool force_recrawl)
-  /***************************************************************************/
-  {
-    //Pull possible files from manifests of packages which depend on this package and export class
-    std::vector<std::string> paths;
-    ros::package::getPlugins(package, attrib_name, paths, force_recrawl);
-    return paths;
-  }
-
-  template <class T>
-  std::map<std::string, ClassDesc> ClassLoader<T>::determineAvailableClasses(const std::vector<std::string>& plugin_xml_paths)
-  /***************************************************************************/
-  {
-    //mas - This method requires major refactoring...not only is it really long and confusing but a lot of the comments do not seem to be correct. With time I keep correcting small things, but a good rewrite is needed.
-
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Entering determineAvailableClasses()...");
-    std::map<std::string, ClassDesc> classes_available;
-
-    //Walk the list of all plugin XML files (variable "paths") that are exported by the build system
-    for (std::vector<std::string>::const_iterator it = plugin_xml_paths.begin(); it != plugin_xml_paths.end(); ++it)
-    {
-      processSingleXMLPluginFile(*it, classes_available);
-    }
-
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Exiting determineAvailableClasses()...");
-    return classes_available;
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::extractPackageNameFromPackageXML(const std::string& package_xml_path)
- /***************************************************************************/
-  {
-      tinyxml2::XMLDocument document;
-      document.LoadFile(package_xml_path.c_str());
-      tinyxml2::XMLElement* doc_root_node = document.FirstChildElement("package");
-      if (doc_root_node == NULL)
-      {
-        ROS_ERROR_NAMED("pluginlib.ClassLoader","Could not find a root element for package manifest at %s.", package_xml_path.c_str());
-        return "";
-      }
-
-      assert(doc_root_node == document.RootElement());
-
-      tinyxml2::XMLElement* package_name_node = doc_root_node->FirstChildElement("name");
-      if(package_name_node == NULL)
-      {
-        ROS_ERROR_NAMED("pluginlib.ClassLoader","package.xml at %s does not have a <name> tag! Cannot determine package which exports plugin.", package_xml_path.c_str());
-        return "";
-      }
-
-      return(package_name_node->GetText());
-  }
-
-  template <class T>
-  std::vector<std::string> ClassLoader<T>::getCatkinLibraryPaths()
-  /***************************************************************************/
-  {
-    return(catkinFindLib());
-  }
-
-  template <class T>
-  std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(const std::string& library_name, const std::string& exporting_package_name)
-  /***************************************************************************/
-  {
-    //Catkin-rosbuild Backwards Compatability Rules - Note library_name may be prefixed with relative path (e.g. "/lib/libFoo")
-    //1. Try catkin library paths (catkin_find --libs) + library_name + extension
-    //2. Try catkin library paths (catkin_find -- libs) + stripAllButFileFromPath(library_name) + extension
-    //3. Try export_pkg/library_name + extension
-
-    std::vector<std::string> all_paths;
-    std::vector<std::string> all_paths_without_extension = getCatkinLibraryPaths();
-    all_paths_without_extension.push_back(getROSBuildLibraryPath(exporting_package_name));
-    bool debug_library_suffix = (class_loader::systemLibrarySuffix().compare(0, 1, "d") == 0);
-    std::string non_debug_suffix;
-    if(debug_library_suffix) {
-        non_debug_suffix = class_loader::systemLibrarySuffix().substr(1);
-    } else {
-        non_debug_suffix = class_loader::systemLibrarySuffix();
-    }
-    std::string library_name_with_extension = library_name + non_debug_suffix;
-    std::string stripped_library_name = stripAllButFileFromPath(library_name);
-    std::string stripped_library_name_with_extension = stripped_library_name + non_debug_suffix;
-
-    const std::string path_separator = getPathSeparator();
-
-    for(unsigned int c = 0; c < all_paths_without_extension.size(); c++)
-    {
-      std::string current_path = all_paths_without_extension.at(c);
-      all_paths.push_back(current_path + path_separator + library_name_with_extension);
-      all_paths.push_back(current_path + path_separator + stripped_library_name_with_extension);
-      // We're in debug mode, try debug libraries as well
-      if(debug_library_suffix) {
-          all_paths.push_back(current_path + path_separator + library_name + class_loader::systemLibrarySuffix());
-          all_paths.push_back(current_path + path_separator + stripped_library_name + class_loader::systemLibrarySuffix());
-      }
-    }
-
-    return(all_paths);
-  }
-
-  template <class T>
-  bool ClassLoader<T>::isClassLoaded(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    return lowlevel_class_loader_.isClassAvailable<T>(getClassType(lookup_name)); //mas - (DONE)
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getBaseClassType() const
-  /***************************************************************************/
-  {
-    return base_class_;
-  }
-
-    template <class T>
-  std::string ClassLoader<T>::getClassDescription(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ClassMapIterator it = classes_available_.find(lookup_name);
-    if (it != classes_available_.end())
-      return it->second.description_;
-    return "";
-  }
-
-    template <class T>
-  std::string ClassLoader<T>::getClassType(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ClassMapIterator it = classes_available_.find(lookup_name);
-    if (it != classes_available_.end())
-      return it->second.derived_class_;
-    return "";
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getClassLibraryPath(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    if (classes_available_.find(lookup_name) == classes_available_.end())
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Class %s has no mapping in classes_available_.", lookup_name.c_str());
-      return "";
-    }
-    ClassMapIterator it = classes_available_.find(lookup_name);
-    std::string library_name = it->second.library_name_;
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Class %s maps to library %s in classes_available_.", lookup_name.c_str(), library_name.c_str());
-
-    std::vector<std::string> paths_to_try = getAllLibraryPathsToTry(library_name, it->second.package_);
-
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Iterating through all possible paths where %s could be located...", library_name.c_str());
-    for(std::vector<std::string>::const_iterator it = paths_to_try.begin(); it != paths_to_try.end(); it++)
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Checking path %s ", it->c_str());
-      if (boost::filesystem::exists(*it))
-      {
-        ROS_DEBUG_NAMED("pluginlib.ClassLoader","Library %s found at explicit path %s.", library_name.c_str(), it->c_str());
-        return *it;
-      }
-    }
-    return "";
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getClassPackage(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ClassMapIterator it = classes_available_.find(lookup_name);
-    if (it != classes_available_.end())
-      return it->second.package_;
-    return "";
-  }
-
-  template <class T>
-  std::vector<std::string> ClassLoader<T>::getPluginXmlPaths()
-  /***************************************************************************/
-  {
-    return plugin_xml_paths_;
-  }
-
-  template <class T>
-  std::vector<std::string> ClassLoader<T>::getDeclaredClasses()
-  /***************************************************************************/
-  {
-    std::vector<std::string> lookup_names;
-    for (ClassMapIterator it = classes_available_.begin(); it != classes_available_.end(); ++it)
-      lookup_names.push_back(it->first);
-
-    return lookup_names;
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getErrorStringForUnknownClass(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    std::string declared_types;
-    std::vector<std::string> types = getDeclaredClasses();
-    for ( unsigned int i = 0; i < types.size(); i ++)
-    {
-      declared_types = declared_types + std::string(" ") + types[i];
-    }
-    return "According to the loaded plugin descriptions the class " + lookup_name
-      + " with base class type " + base_class_ + " does not exist. Declared types are " + declared_types;
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getName(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    //remove the package name to get the raw plugin name
-    std::vector<std::string> split;
-    boost::split(split, lookup_name, boost::is_any_of("/:"));
-    return split.back();
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getPackageFromPluginXMLFilePath(const std::string & plugin_xml_file_path)
- /***************************************************************************/
-  {
-    //Note: This method takes an input a path to a plugin xml file and must determine which
-    //package the XML file came from. This is not necessariliy the same thing as the member
-    //variable "package_". The plugin xml file can be located anywhere in the source tree for a
-    //package
-
-    //rosbuild:
-    //1. Find nearest encasing manifest.xml
-    //2. Once found, the name of the folder containg the manifest should be the package name we are looking for
-    //3. Confirm package is findable with rospack
-
-    //catkin:
-    //1. Find nearest encasing package.xml
-    //2. Extract name of package from package.xml
-
-    std::string package_name;
-    boost::filesystem::path p(plugin_xml_file_path);
-    boost::filesystem::path parent = p.parent_path();
-
-    //Figure out exactly which package the passed XML file is exported by.
-    while (true)
-    {
-      if(boost::filesystem::exists(parent / "package.xml"))
-      {
-        std::string package_file_path = (boost::filesystem::path(parent / "package.xml")).string();
-        return(extractPackageNameFromPackageXML(package_file_path));
-      }
-      else if (boost::filesystem::exists(parent / "manifest.xml"))
-      {
-#if BOOST_FILESYSTEM_VERSION >= 3
-        std::string package = parent.filename().string();
-#else
-        std::string package = parent.filename();
-#endif
-        std::string package_path = ros::package::getPath(package);
-
-        if (plugin_xml_file_path.find(package_path) == 0) //package_path is a substr of passed plugin xml path
-        {
-          package_name = package;
-          break;
-        }
-      }
-
-      //Recursive case - hop one folder up
-      parent = parent.parent_path().string();
-
-      //Base case - reached root and cannot find what we're looking for
-      if (parent.string().empty())
-        return "";
-    }
-
-    return package_name;
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getPathSeparator()
-  /***************************************************************************/
-  {
-#if BOOST_FILESYSTEM_VERSION >= 3
-    return(boost::filesystem::path("/").native());
-#else
-    return(boost::filesystem::path("/").external_file_string());
-#endif
-  }
-
-
-  template <class T>
-  std::string ClassLoader<T>::getPluginManifestPath(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ClassMapIterator it = classes_available_.find(lookup_name);
-    if (it != classes_available_.end())
-      return it->second.plugin_manifest_path_;
-    return "";
-  }
-
-
-  template <class T>
-  std::vector<std::string> ClassLoader<T>::getRegisteredLibraries()
-  /***************************************************************************/
-  {
-    return(lowlevel_class_loader_.getRegisteredLibraries());
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::getROSBuildLibraryPath(const std::string& exporting_package_name)
-  /***************************************************************************/
-  {
-    return(ros::package::getPath(exporting_package_name));
-  }
-
-  template <class T>
-  bool ClassLoader<T>::isClassAvailable(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    return classes_available_.find(lookup_name) != classes_available_.end();
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::joinPaths(const std::string& path1, const std::string& path2)
-  /***************************************************************************/
-  {
-    boost::filesystem::path p1(path1);
-    return (p1 / path2).string();
-  }
-
-  template <class T>
-  void ClassLoader<T>::loadLibraryForClass(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ClassMapIterator it = classes_available_.find(lookup_name);
-    if (it == classes_available_.end())
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Class %s has no mapping in classes_available_.", lookup_name.c_str());
-      throw pluginlib::LibraryLoadException(getErrorStringForUnknownClass(lookup_name));
-    }
-
-    std::string library_path = getClassLibraryPath(lookup_name);
-    if (library_path == "")
-    {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","No path could be found to the library containing %s.", lookup_name.c_str());
-      std::ostringstream error_msg;
-      error_msg << "Could not find library corresponding to plugin " << lookup_name << ". Make sure the plugin description XML file has the correct name of the library and that the library actually exists.";
-      throw pluginlib::LibraryLoadException(error_msg.str());
-    }
-
-    try
-    {
-      lowlevel_class_loader_.loadLibrary(library_path);
-      it->second.resolved_library_path_ = library_path;
-    }
-    catch(const class_loader::LibraryLoadException& ex)
-    {
-      std::string error_string = "Failed to load library " + library_path + ". Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: " + ex.what();
-      throw pluginlib::LibraryLoadException(error_string);
-    }
-  }
-
-  template <class T>
-  void ClassLoader<T>::processSingleXMLPluginFile(const std::string& xml_file, std::map<std::string, ClassDesc>& classes_available)
-  /***************************************************************************/
-  {
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Processing xml file %s...", xml_file.c_str());
-    tinyxml2::XMLDocument document;
-    document.LoadFile(xml_file.c_str());
-    tinyxml2::XMLElement * config = document.RootElement();
-    if (config == NULL)
-    {
-      throw pluginlib::InvalidXMLException("XML Document has no Root Element.  This likely means the XML is malformed or missing.");
-      return;
-    }
-    if (!(strcmp(config->Value(), "library") == 0 ||
-          strcmp(config->Value(), "class_libraries") == 0))
-    {
-      throw pluginlib::InvalidXMLException("The XML document given to add must have either \"library\" or \
-          \"class_libraries\" as the root tag");
-      return;
-    }
-    //Step into the filter list if necessary
-    if (strcmp(config->Value(), "class_libraries") == 0)
-    {
-      config = config->FirstChildElement("library");
-    }
-
-    tinyxml2::XMLElement* library = config;
-    while ( library != NULL)
-    {
-      std::string library_path = library->Attribute("path");
-      if (library_path.size() == 0)
-      {
-        ROS_ERROR_NAMED("pluginlib.ClassLoader","Failed to find Path Attirbute in library element in %s", xml_file.c_str());
-        continue;
-      }
-
-      std::string package_name = getPackageFromPluginXMLFilePath(xml_file);
-      if (package_name == "")
-        ROS_ERROR_NAMED("pluginlib.ClassLoader","Could not find package manifest (neither package.xml or deprecated manifest.xml) at same directory level as the plugin XML file %s. Plugins will likely not be exported properly.\n)", xml_file.c_str());
-
-      tinyxml2::XMLElement* class_element = library->FirstChildElement("class");
-      while (class_element)
-      {
-        std::string derived_class;
-        if (class_element->Attribute("type") != NULL) {
-          derived_class = std::string(class_element->Attribute("type"));
-        } else {
-          throw pluginlib::ClassLoaderException("Class could not be loaded. Attribute 'type' in class tag is missing.");
-        }
-
-        std::string base_class_type;
-        if (class_element->Attribute("base_class_type") != NULL) {
-          base_class_type = std::string(class_element->Attribute("base_class_type"));
-        } else {
-          throw pluginlib::ClassLoaderException("Class could not be loaded. Attribute 'base_class_type' in class tag is missing.");
-        }
-
-        std::string lookup_name;
-        if(class_element->Attribute("name") != NULL)
-        {
-          lookup_name = class_element->Attribute("name");
-          ROS_DEBUG_NAMED("pluginlib.ClassLoader","XML file specifies lookup name (i.e. magic name) = %s.", lookup_name.c_str());
-        }
-        else
-        {
-          ROS_DEBUG_NAMED("pluginlib.ClassLoader","XML file has no lookup name (i.e. magic name) for class %s, assuming lookup_name == real class name.", derived_class.c_str());
-          lookup_name = derived_class;
-        }
-
-        //make sure that this class is of the right type before registering it
-        if(base_class_type == base_class_){
-
-          // register class here
-          tinyxml2::XMLElement* description = class_element->FirstChildElement("description");
-          std::string description_str;
-          if (description)
-            description_str = description->GetText() ? description->GetText() : "";
-          else
-            description_str = "No 'description' tag for this plugin in plugin description file.";
-
-          classes_available.insert(std::pair<std::string, ClassDesc>(lookup_name, ClassDesc(lookup_name, derived_class, base_class_type, package_name, description_str, library_path, xml_file)));
-        }
-
-        //step to next class_element
-        class_element = class_element->NextSiblingElement( "class" );
-      }
-      library = library->NextSiblingElement( "library" );
-    }
-  }
-
-  template <class T>
-  void ClassLoader<T>::refreshDeclaredClasses()
-  /***************************************************************************/
-  {
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader","Refreshing declared classes.");
-    // determine classes not currently loaded for removal
-    std::list<std::string> remove_classes;
-    for (std::map<std::string, ClassDesc>::const_iterator it = classes_available_.begin(); it != classes_available_.end(); it++)
-    {
-
-      std::string resolved_library_path = it->second.resolved_library_path_;
-      std::vector<std::string> open_libs = lowlevel_class_loader_.getRegisteredLibraries();
-      if(std::find(open_libs.begin(), open_libs.end(), resolved_library_path) != open_libs.end())
-        remove_classes.push_back(it->first);
-    }
-
-    while (!remove_classes.empty())
-    {
-      classes_available_.erase(remove_classes.front());
-      remove_classes.pop_front();
-    }
-
-    // add new classes
-    plugin_xml_paths_ = getPluginXmlPaths(package_, attrib_name_, true);
-    std::map<std::string, ClassDesc> updated_classes = determineAvailableClasses(plugin_xml_paths_);
-    for (std::map<std::string, ClassDesc>::const_iterator it = updated_classes.begin(); it != updated_classes.end(); it++)
-    {
-      if (classes_available_.find(it->first) == classes_available_.end())
-        classes_available_.insert(std::pair<std::string, ClassDesc>(it->first, it->second));
-    }
-  }
-
-  template <class T>
-  std::string ClassLoader<T>::stripAllButFileFromPath(const std::string& path)
-  /***************************************************************************/
-  {
-    std::string only_file;
-    size_t c = path.find_last_of(getPathSeparator());
-    if(c == std::string::npos)
-      return(path);
-    else
-      return(path.substr(c, path.size()));
-  }
-
-  template <class T>
-  int ClassLoader<T>::unloadLibraryForClass(const std::string& lookup_name)
-  /***************************************************************************/
-  {
-    ClassMapIterator it = classes_available_.find(lookup_name);
-    if (it != classes_available_.end() && it->second.resolved_library_path_ != "UNRESOLVED")
-    {
-      std::string library_path = it->second.resolved_library_path_;
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader","Attempting to unload library %s for class %s", library_path.c_str(), lookup_name.c_str());
-      return unloadClassLibraryInternal(library_path);
-    }
-    else
-    {
-      throw pluginlib::LibraryUnloadException(getErrorStringForUnknownClass(lookup_name));
-    }
-  }
-
-  template <class T>
-  int ClassLoader<T>::unloadClassLibraryInternal(const std::string& library_path)
-  /***************************************************************************/
-  {
-    return(lowlevel_class_loader_.unloadLibrary(library_path));
-  }
-
+  classes_available_ = determineAvailableClasses(plugin_xml_paths_);
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+    "Finished constructring ClassLoader, base = %s, address = %p",
+    base_class.c_str(), this);
+}
+
+template<class T>
+ClassLoader<T>::~ClassLoader()
+/***************************************************************************/
+{
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Destroying ClassLoader, base = %s, address = %p",
+    getBaseClassType().c_str(), this);
 }
 
 
+template<class T>
+T * ClassLoader<T>::createClassInstance(const std::string & lookup_name, bool auto_load)
+/***************************************************************************/
+{
+  //Note: This method is deprecated
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+    "In deprecated call createClassInstance(), lookup_name = %s, auto_load = %i.",
+    (lookup_name.c_str()), auto_load);
+
+  if (auto_load && !isClassLoaded(lookup_name)) {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+      "Autoloading class library before attempting to create instance.");
+    loadLibraryForClass(lookup_name);
+  }
+
+  try {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+      "Attempting to create instance through low-level MultiLibraryClassLoader...");
+    T * obj = lowlevel_class_loader_.createUnmanagedInstance<T>(getClassType(lookup_name));
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Instance created with object pointer = %p", obj);
+
+    return obj;
+  } catch (const class_loader::CreateClassException & ex) {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "CreateClassException about to be raised for class %s",
+      lookup_name.c_str());
+    throw pluginlib::CreateClassException(ex.what());
+  }
+}
+
+template<class T>
+boost::shared_ptr<T> ClassLoader<T>::createInstance(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Attempting to create managed instance for class %s.",
+    lookup_name.c_str());
+
+  if (!isClassLoaded(lookup_name)) {
+    loadLibraryForClass(lookup_name);
+  }
+
+  try {
+    std::string class_type = getClassType(lookup_name);
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "%s maps to real class type %s",
+      lookup_name.c_str(), class_type.c_str());
+
+    boost::shared_ptr<T> obj = lowlevel_class_loader_.createInstance<T>(class_type);
+
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "boost::shared_ptr to object of real type %s created.",
+      class_type.c_str());
+
+    return obj;
+  } catch (const class_loader::CreateClassException & ex) {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+      "Exception raised by low-level multi-library class loader when attempting to create instance of class %s.",
+      lookup_name.c_str());
+    throw pluginlib::CreateClassException(ex.what());
+  }
+}
+
+#if __cplusplus >= 201103L
+template<class T>
+UniquePtr<T> ClassLoader<T>::createUniqueInstance(const std::string & lookup_name)
+{
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+    "Attempting to create managed (unique) instance for class %s.",
+    lookup_name.c_str());
+
+  if (!isClassLoaded(lookup_name)) {
+    loadLibraryForClass(lookup_name);
+  }
+
+  try {
+    std::string class_type = getClassType(lookup_name);
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "%s maps to real class type %s",
+      lookup_name.c_str(), class_type.c_str());
+
+    UniquePtr<T> obj = lowlevel_class_loader_.createUniqueInstance<T>(class_type);
+
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "std::unique_ptr to object of real type %s created.",
+      class_type.c_str());
+
+    return obj;
+  } catch (const class_loader::CreateClassException & ex) {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+      "Exception raised by low-level multi-library class loader when attempting to create instance of class %s.",
+      lookup_name.c_str());
+    throw pluginlib::CreateClassException(ex.what());
+  }
+
+}
+#endif
+
+template<class T>
+T * ClassLoader<T>::createUnmanagedInstance(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Attempting to create UNMANAGED instance for class %s.",
+    lookup_name.c_str());
+
+  if (!isClassLoaded(lookup_name)) {
+    loadLibraryForClass(lookup_name);
+  }
+
+  T * instance = 0;
+  try {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+      "Attempting to create instance through low level multi-library class loader.");
+    std::string class_type = getClassType(lookup_name);
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "%s maps to real class type %s",
+      lookup_name.c_str(), class_type.c_str());
+    instance = lowlevel_class_loader_.createUnmanagedInstance<T>(class_type);
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Instance of type %s created.", class_type.c_str());
+  } catch (const class_loader::CreateClassException & ex) { //mas - change exception type here (DONE)
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+      "Exception raised by low-level multi-library class loader when attempting to create UNMANAGED instance of class %s.",
+      lookup_name.c_str());
+    throw pluginlib::CreateClassException(ex.what());
+  }
+  return instance;
+}
+
+template<class T>
+std::vector<std::string> ClassLoader<T>::getPluginXmlPaths(
+  const std::string & package,
+  const std::string & attrib_name,
+  bool force_recrawl)
+/***************************************************************************/
+{
+  //Pull possible files from manifests of packages which depend on this package and export class
+  std::vector<std::string> paths;
+  ros::package::getPlugins(package, attrib_name, paths, force_recrawl);
+  return paths;
+}
+
+template<class T>
+std::map<std::string, ClassDesc> ClassLoader<T>::determineAvailableClasses(
+  const std::vector<std::string> & plugin_xml_paths)
+/***************************************************************************/
+{
+  //mas - This method requires major refactoring...not only is it really long and confusing but a lot of the comments do not seem to be correct. With time I keep correcting small things, but a good rewrite is needed.
+
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Entering determineAvailableClasses()...");
+  std::map<std::string, ClassDesc> classes_available;
+
+  //Walk the list of all plugin XML files (variable "paths") that are exported by the build system
+  for (std::vector<std::string>::const_iterator it = plugin_xml_paths.begin();
+    it != plugin_xml_paths.end(); ++it)
+  {
+    processSingleXMLPluginFile(*it, classes_available);
+  }
+
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Exiting determineAvailableClasses()...");
+  return classes_available;
+}
+
+template<class T>
+std::string ClassLoader<T>::extractPackageNameFromPackageXML(const std::string & package_xml_path)
+/***************************************************************************/
+{
+  tinyxml2::XMLDocument document;
+  document.LoadFile(package_xml_path.c_str());
+  tinyxml2::XMLElement * doc_root_node = document.FirstChildElement("package");
+  if (doc_root_node == NULL) {
+    ROS_ERROR_NAMED("pluginlib.ClassLoader",
+      "Could not find a root element for package manifest at %s.",
+      package_xml_path.c_str());
+    return "";
+  }
+
+  assert(doc_root_node == document.RootElement());
+
+  tinyxml2::XMLElement * package_name_node = doc_root_node->FirstChildElement("name");
+  if (package_name_node == NULL) {
+    ROS_ERROR_NAMED("pluginlib.ClassLoader",
+      "package.xml at %s does not have a <name> tag! Cannot determine package which exports plugin.",
+      package_xml_path.c_str());
+    return "";
+  }
+
+  return package_name_node->GetText();
+}
+
+template<class T>
+std::vector<std::string> ClassLoader<T>::getCatkinLibraryPaths()
+/***************************************************************************/
+{
+  return catkinFindLib();
+}
+
+template<class T>
+std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
+  const std::string & library_name,
+  const std::string & exporting_package_name)
+/***************************************************************************/
+{
+  //Catkin-rosbuild Backwards Compatability Rules - Note library_name may be prefixed with relative path (e.g. "/lib/libFoo")
+  //1. Try catkin library paths (catkin_find --libs) + library_name + extension
+  //2. Try catkin library paths (catkin_find -- libs) + stripAllButFileFromPath(library_name) + extension
+  //3. Try export_pkg/library_name + extension
+
+  std::vector<std::string> all_paths;
+  std::vector<std::string> all_paths_without_extension = getCatkinLibraryPaths();
+  all_paths_without_extension.push_back(getROSBuildLibraryPath(exporting_package_name));
+  bool debug_library_suffix = (class_loader::systemLibrarySuffix().compare(0, 1, "d") == 0);
+  std::string non_debug_suffix;
+  if (debug_library_suffix) {
+    non_debug_suffix = class_loader::systemLibrarySuffix().substr(1);
+  } else {
+    non_debug_suffix = class_loader::systemLibrarySuffix();
+  }
+  std::string library_name_with_extension = library_name + non_debug_suffix;
+  std::string stripped_library_name = stripAllButFileFromPath(library_name);
+  std::string stripped_library_name_with_extension = stripped_library_name + non_debug_suffix;
+
+  const std::string path_separator = getPathSeparator();
+
+  for (unsigned int c = 0; c < all_paths_without_extension.size(); c++) {
+    std::string current_path = all_paths_without_extension.at(c);
+    all_paths.push_back(current_path + path_separator + library_name_with_extension);
+    all_paths.push_back(current_path + path_separator + stripped_library_name_with_extension);
+    // We're in debug mode, try debug libraries as well
+    if (debug_library_suffix) {
+      all_paths.push_back(
+        current_path + path_separator + library_name + class_loader::systemLibrarySuffix());
+      all_paths.push_back(
+        current_path + path_separator + stripped_library_name +
+        class_loader::systemLibrarySuffix());
+    }
+  }
+
+  return all_paths;
+}
+
+template<class T>
+bool ClassLoader<T>::isClassLoaded(const std::string & lookup_name)
+/***************************************************************************/
+{
+  return lowlevel_class_loader_.isClassAvailable<T>(getClassType(lookup_name));   //mas - (DONE)
+}
+
+template<class T>
+std::string ClassLoader<T>::getBaseClassType() const
+/***************************************************************************/
+{
+  return base_class_;
+}
+
+template<class T>
+std::string ClassLoader<T>::getClassDescription(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ClassMapIterator it = classes_available_.find(lookup_name);
+  if (it != classes_available_.end()) {
+    return it->second.description_;
+  }
+  return "";
+}
+
+template<class T>
+std::string ClassLoader<T>::getClassType(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ClassMapIterator it = classes_available_.find(lookup_name);
+  if (it != classes_available_.end()) {
+    return it->second.derived_class_;
+  }
+  return "";
+}
+
+template<class T>
+std::string ClassLoader<T>::getClassLibraryPath(const std::string & lookup_name)
+/***************************************************************************/
+{
+  if (classes_available_.find(lookup_name) == classes_available_.end()) {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Class %s has no mapping in classes_available_.",
+      lookup_name.c_str());
+    return "";
+  }
+  ClassMapIterator it = classes_available_.find(lookup_name);
+  std::string library_name = it->second.library_name_;
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Class %s maps to library %s in classes_available_.",
+    lookup_name.c_str(), library_name.c_str());
+
+  std::vector<std::string> paths_to_try =
+    getAllLibraryPathsToTry(library_name, it->second.package_);
+
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+    "Iterating through all possible paths where %s could be located...",
+    library_name.c_str());
+  for (std::vector<std::string>::const_iterator it = paths_to_try.begin(); it != paths_to_try.end();
+    it++)
+  {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Checking path %s ", it->c_str());
+    if (boost::filesystem::exists(*it)) {
+      ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Library %s found at explicit path %s.",
+        library_name.c_str(), it->c_str());
+      return *it;
+    }
+  }
+  return "";
+}
+
+template<class T>
+std::string ClassLoader<T>::getClassPackage(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ClassMapIterator it = classes_available_.find(lookup_name);
+  if (it != classes_available_.end()) {
+    return it->second.package_;
+  }
+  return "";
+}
+
+template<class T>
+std::vector<std::string> ClassLoader<T>::getPluginXmlPaths()
+/***************************************************************************/
+{
+  return plugin_xml_paths_;
+}
+
+template<class T>
+std::vector<std::string> ClassLoader<T>::getDeclaredClasses()
+/***************************************************************************/
+{
+  std::vector<std::string> lookup_names;
+  for (ClassMapIterator it = classes_available_.begin(); it != classes_available_.end(); ++it) {
+    lookup_names.push_back(it->first);
+  }
+
+  return lookup_names;
+}
+
+template<class T>
+std::string ClassLoader<T>::getErrorStringForUnknownClass(const std::string & lookup_name)
+/***************************************************************************/
+{
+  std::string declared_types;
+  std::vector<std::string> types = getDeclaredClasses();
+  for (unsigned int i = 0; i < types.size(); i++) {
+    declared_types = declared_types + std::string(" ") + types[i];
+  }
+  return "According to the loaded plugin descriptions the class " + lookup_name +
+         " with base class type " + base_class_ + " does not exist. Declared types are " +
+         declared_types;
+}
+
+template<class T>
+std::string ClassLoader<T>::getName(const std::string & lookup_name)
+/***************************************************************************/
+{
+  //remove the package name to get the raw plugin name
+  std::vector<std::string> split;
+  boost::split(split, lookup_name, boost::is_any_of("/:"));
+  return split.back();
+}
+
+template<class T>
+std::string ClassLoader<T>::getPackageFromPluginXMLFilePath(const std::string & plugin_xml_file_path)
+/***************************************************************************/
+{
+  //Note: This method takes an input a path to a plugin xml file and must determine which
+  //package the XML file came from. This is not necessariliy the same thing as the member
+  //variable "package_". The plugin xml file can be located anywhere in the source tree for a
+  //package
+
+  //rosbuild:
+  //1. Find nearest encasing manifest.xml
+  //2. Once found, the name of the folder containg the manifest should be the package name we are looking for
+  //3. Confirm package is findable with rospack
+
+  //catkin:
+  //1. Find nearest encasing package.xml
+  //2. Extract name of package from package.xml
+
+  std::string package_name;
+  boost::filesystem::path p(plugin_xml_file_path);
+  boost::filesystem::path parent = p.parent_path();
+
+  //Figure out exactly which package the passed XML file is exported by.
+  while (true) {
+    if (boost::filesystem::exists(parent / "package.xml")) {
+      std::string package_file_path = (boost::filesystem::path(parent / "package.xml")).string();
+      return extractPackageNameFromPackageXML(package_file_path);
+    } else if (boost::filesystem::exists(parent / "manifest.xml")) {
+#if BOOST_FILESYSTEM_VERSION >= 3
+      std::string package = parent.filename().string();
+#else
+      std::string package = parent.filename();
+#endif
+      std::string package_path = ros::package::getPath(package);
+
+      if (plugin_xml_file_path.find(package_path) == 0) { //package_path is a substr of passed plugin xml path
+        package_name = package;
+        break;
+      }
+    }
+
+    //Recursive case - hop one folder up
+    parent = parent.parent_path().string();
+
+    //Base case - reached root and cannot find what we're looking for
+    if (parent.string().empty()) {
+      return "";
+    }
+  }
+
+  return package_name;
+}
+
+template<class T>
+std::string ClassLoader<T>::getPathSeparator()
+/***************************************************************************/
+{
+#if BOOST_FILESYSTEM_VERSION >= 3
+  return boost::filesystem::path("/").native();
+#else
+  return boost::filesystem::path("/").external_file_string();
+#endif
+}
+
+
+template<class T>
+std::string ClassLoader<T>::getPluginManifestPath(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ClassMapIterator it = classes_available_.find(lookup_name);
+  if (it != classes_available_.end()) {
+    return it->second.plugin_manifest_path_;
+  }
+  return "";
+}
+
+
+template<class T>
+std::vector<std::string> ClassLoader<T>::getRegisteredLibraries()
+/***************************************************************************/
+{
+  return lowlevel_class_loader_.getRegisteredLibraries();
+}
+
+template<class T>
+std::string ClassLoader<T>::getROSBuildLibraryPath(const std::string & exporting_package_name)
+/***************************************************************************/
+{
+  return ros::package::getPath(exporting_package_name);
+}
+
+template<class T>
+bool ClassLoader<T>::isClassAvailable(const std::string & lookup_name)
+/***************************************************************************/
+{
+  return classes_available_.find(lookup_name) != classes_available_.end();
+}
+
+template<class T>
+std::string ClassLoader<T>::joinPaths(const std::string & path1, const std::string & path2)
+/***************************************************************************/
+{
+  boost::filesystem::path p1(path1);
+  return (p1 / path2).string();
+}
+
+template<class T>
+void ClassLoader<T>::loadLibraryForClass(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ClassMapIterator it = classes_available_.find(lookup_name);
+  if (it == classes_available_.end()) {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Class %s has no mapping in classes_available_.",
+      lookup_name.c_str());
+    throw pluginlib::LibraryLoadException(getErrorStringForUnknownClass(lookup_name));
+  }
+
+  std::string library_path = getClassLibraryPath(lookup_name);
+  if (library_path == "") {
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "No path could be found to the library containing %s.",
+      lookup_name.c_str());
+    std::ostringstream error_msg;
+    error_msg << "Could not find library corresponding to plugin " << lookup_name <<
+      ". Make sure the plugin description XML file has the correct name of the library and that the library actually exists.";
+    throw pluginlib::LibraryLoadException(error_msg.str());
+  }
+
+  try {
+    lowlevel_class_loader_.loadLibrary(library_path);
+    it->second.resolved_library_path_ = library_path;
+  } catch (const class_loader::LibraryLoadException & ex) {
+    std::string error_string = "Failed to load library " + library_path +
+      ". Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: "
+      +
+      ex.what();
+    throw pluginlib::LibraryLoadException(error_string);
+  }
+}
+
+template<class T>
+void ClassLoader<T>::processSingleXMLPluginFile(
+  const std::string & xml_file, std::map<std::string,
+  ClassDesc> & classes_available)
+/***************************************************************************/
+{
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Processing xml file %s...", xml_file.c_str());
+  tinyxml2::XMLDocument document;
+  document.LoadFile(xml_file.c_str());
+  tinyxml2::XMLElement * config = document.RootElement();
+  if (config == NULL) {
+    throw pluginlib::InvalidXMLException(
+            "XML Document has no Root Element.  This likely means the XML is malformed or missing.");
+    return;
+  }
+  if (!(strcmp(config->Value(), "library") == 0 ||
+    strcmp(config->Value(), "class_libraries") == 0))
+  {
+    throw pluginlib::InvalidXMLException(
+            "The XML document given to add must have either \"library\" or \
+          \"class_libraries\" as the root tag");
+    return;
+  }
+  //Step into the filter list if necessary
+  if (strcmp(config->Value(), "class_libraries") == 0) {
+    config = config->FirstChildElement("library");
+  }
+
+  tinyxml2::XMLElement * library = config;
+  while (library != NULL) {
+    std::string library_path = library->Attribute("path");
+    if (library_path.size() == 0) {
+      ROS_ERROR_NAMED("pluginlib.ClassLoader",
+        "Failed to find Path Attirbute in library element in %s", xml_file.c_str());
+      continue;
+    }
+
+    std::string package_name = getPackageFromPluginXMLFilePath(xml_file);
+    if (package_name == "") {
+      ROS_ERROR_NAMED("pluginlib.ClassLoader",
+        "Could not find package manifest (neither package.xml or deprecated manifest.xml) at same directory level as the plugin XML file %s. Plugins will likely not be exported properly.\n)",
+        xml_file.c_str());
+    }
+
+    tinyxml2::XMLElement * class_element = library->FirstChildElement("class");
+    while (class_element) {
+      std::string derived_class;
+      if (class_element->Attribute("type") != NULL) {
+        derived_class = std::string(class_element->Attribute("type"));
+      } else {
+        throw pluginlib::ClassLoaderException(
+                "Class could not be loaded. Attribute 'type' in class tag is missing.");
+      }
+
+      std::string base_class_type;
+      if (class_element->Attribute("base_class_type") != NULL) {
+        base_class_type = std::string(class_element->Attribute("base_class_type"));
+      } else {
+        throw pluginlib::ClassLoaderException(
+                "Class could not be loaded. Attribute 'base_class_type' in class tag is missing.");
+      }
+
+      std::string lookup_name;
+      if (class_element->Attribute("name") != NULL) {
+        lookup_name = class_element->Attribute("name");
+        ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+          "XML file specifies lookup name (i.e. magic name) = %s.",
+          lookup_name.c_str());
+      } else {
+        ROS_DEBUG_NAMED("pluginlib.ClassLoader",
+          "XML file has no lookup name (i.e. magic name) for class %s, assuming lookup_name == real class name.",
+          derived_class.c_str());
+        lookup_name = derived_class;
+      }
+
+      //make sure that this class is of the right type before registering it
+      if (base_class_type == base_class_) {
+
+        // register class here
+        tinyxml2::XMLElement * description = class_element->FirstChildElement("description");
+        std::string description_str;
+        if (description) {
+          description_str = description->GetText() ? description->GetText() : "";
+        } else {
+          description_str = "No 'description' tag for this plugin in plugin description file.";
+        }
+
+        classes_available.insert(std::pair<std::string, ClassDesc>(lookup_name,
+          ClassDesc(lookup_name, derived_class, base_class_type, package_name, description_str,
+          library_path, xml_file)));
+      }
+
+      //step to next class_element
+      class_element = class_element->NextSiblingElement("class");
+    }
+    library = library->NextSiblingElement("library");
+  }
+}
+
+template<class T>
+void ClassLoader<T>::refreshDeclaredClasses()
+/***************************************************************************/
+{
+  ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Refreshing declared classes.");
+  // determine classes not currently loaded for removal
+  std::list<std::string> remove_classes;
+  for (std::map<std::string, ClassDesc>::const_iterator it = classes_available_.begin();
+    it != classes_available_.end(); it++)
+  {
+
+    std::string resolved_library_path = it->second.resolved_library_path_;
+    std::vector<std::string> open_libs = lowlevel_class_loader_.getRegisteredLibraries();
+    if (std::find(open_libs.begin(), open_libs.end(), resolved_library_path) != open_libs.end()) {
+      remove_classes.push_back(it->first);
+    }
+  }
+
+  while (!remove_classes.empty()) {
+    classes_available_.erase(remove_classes.front());
+    remove_classes.pop_front();
+  }
+
+  // add new classes
+  plugin_xml_paths_ = getPluginXmlPaths(package_, attrib_name_, true);
+  std::map<std::string, ClassDesc> updated_classes = determineAvailableClasses(plugin_xml_paths_);
+  for (std::map<std::string, ClassDesc>::const_iterator it = updated_classes.begin();
+    it != updated_classes.end(); it++)
+  {
+    if (classes_available_.find(it->first) == classes_available_.end()) {
+      classes_available_.insert(std::pair<std::string, ClassDesc>(it->first, it->second));
+    }
+  }
+}
+
+template<class T>
+std::string ClassLoader<T>::stripAllButFileFromPath(const std::string & path)
+/***************************************************************************/
+{
+  std::string only_file;
+  size_t c = path.find_last_of(getPathSeparator());
+  if (c == std::string::npos) {
+    return path;
+  } else {
+    return path.substr(c, path.size());
+  }
+}
+
+template<class T>
+int ClassLoader<T>::unloadLibraryForClass(const std::string & lookup_name)
+/***************************************************************************/
+{
+  ClassMapIterator it = classes_available_.find(lookup_name);
+  if (it != classes_available_.end() && it->second.resolved_library_path_ != "UNRESOLVED") {
+    std::string library_path = it->second.resolved_library_path_;
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Attempting to unload library %s for class %s",
+      library_path.c_str(), lookup_name.c_str());
+    return unloadClassLibraryInternal(library_path);
+  } else {
+    throw pluginlib::LibraryUnloadException(getErrorStringForUnknownClass(lookup_name));
+  }
+}
+
+template<class T>
+int ClassLoader<T>::unloadClassLibraryInternal(const std::string & library_path)
+/***************************************************************************/
+{
+  return lowlevel_class_loader_.unloadLibrary(library_path);
+}
+
+}
 
 
 #endif

--- a/include/pluginlib/pluginlib_exceptions.h
+++ b/include/pluginlib/pluginlib_exceptions.h
@@ -27,10 +27,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PLUGINLIB_EXCEPTIONS_H_DEFINED
-#define PLUGINLIB_EXCEPTIONS_H_DEFINED
+#ifndef PLUGINLIB__PLUGINLIB_EXCEPTIONS_H_
+#define PLUGINLIB__PLUGINLIB_EXCEPTIONS_H_
 
 #include <stdexcept>
+#include <string>
+
+// TODO(wjwwood): replace no lints with the explicit keyword in an ABI break
 
 namespace pluginlib
 {
@@ -42,7 +45,7 @@ namespace pluginlib
 class PluginlibException : public std::runtime_error
 {
 public:
-  PluginlibException(const std::string error_desc)
+  PluginlibException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : std::runtime_error(error_desc) {}
 };
 
@@ -53,7 +56,7 @@ public:
 class InvalidXMLException : public PluginlibException
 {
 public:
-  InvalidXMLException(const std::string error_desc)
+  InvalidXMLException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : PluginlibException(error_desc) {}
 };
 
@@ -64,7 +67,7 @@ public:
 class LibraryLoadException : public PluginlibException
 {
 public:
-  LibraryLoadException(const std::string error_desc)
+  LibraryLoadException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : PluginlibException(error_desc) {}
 };
 
@@ -75,7 +78,7 @@ public:
 class ClassLoaderException : public PluginlibException
 {
 public:
-  ClassLoaderException(const std::string error_desc)
+  ClassLoaderException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : PluginlibException(error_desc) {}
 };
 
@@ -86,7 +89,7 @@ public:
 class LibraryUnloadException : public PluginlibException
 {
 public:
-  LibraryUnloadException(const std::string error_desc)
+  LibraryUnloadException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : PluginlibException(error_desc) {}
 };
 
@@ -97,11 +100,10 @@ public:
 class CreateClassException : public PluginlibException
 {
 public:
-  CreateClassException(const std::string error_desc)
+  CreateClassException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : PluginlibException(error_desc) {}
 };
 
+}  // namespace pluginlib
 
-}
-
-#endif
+#endif  // PLUGINLIB__PLUGINLIB_EXCEPTIONS_H_

--- a/include/pluginlib/pluginlib_exceptions.h
+++ b/include/pluginlib/pluginlib_exceptions.h
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright (c) 2012, Willow Garage, Inc.
  * All rights reserved.
  *
@@ -39,60 +39,66 @@ namespace pluginlib
  * @class PluginlibException
  * @brief A base class for all pluginlib exceptions that inherits from std::runtime_exception
  */
-class PluginlibException: public std::runtime_error
+class PluginlibException : public std::runtime_error
 {
-  public:
-    PluginlibException(const std::string error_desc) : std::runtime_error(error_desc) {}
+public:
+  PluginlibException(const std::string error_desc)
+  : std::runtime_error(error_desc) {}
 };
 
 /**
  * @class InvalidXMLException
  * @brief An exception class thrown when pluginlib is unable to load a plugin XML file
  */
-class InvalidXMLException: public PluginlibException
+class InvalidXMLException : public PluginlibException
 {
-  public:
-    InvalidXMLException(const std::string error_desc) : PluginlibException(error_desc) {}
+public:
+  InvalidXMLException(const std::string error_desc)
+  : PluginlibException(error_desc) {}
 };
 
 /**
  * @class LibraryLoadException
  * @brief An exception class thrown when pluginlib is unable to load the library associated with a given plugin
  */
-class LibraryLoadException: public PluginlibException
+class LibraryLoadException : public PluginlibException
 {
-  public:
-    LibraryLoadException(const std::string error_desc) : PluginlibException(error_desc) {}
+public:
+  LibraryLoadException(const std::string error_desc)
+  : PluginlibException(error_desc) {}
 };
 
 /**
  * @class ClassLoaderException
  * @brief An exception class thrown when pluginlib is unable to instantiate a class loader
  */
-class ClassLoaderException: public PluginlibException
+class ClassLoaderException : public PluginlibException
 {
-  public:
-    ClassLoaderException(const std::string error_desc) : PluginlibException(error_desc) {}
+public:
+  ClassLoaderException(const std::string error_desc)
+  : PluginlibException(error_desc) {}
 };
 
 /**
  * @class LibraryUnloadException
  * @brief An exception class thrown when pluginlib is unable to unload the library associated with a given plugin
  */
-class LibraryUnloadException: public PluginlibException
+class LibraryUnloadException : public PluginlibException
 {
-  public:
-    LibraryUnloadException(const std::string error_desc) : PluginlibException(error_desc) {}
+public:
+  LibraryUnloadException(const std::string error_desc)
+  : PluginlibException(error_desc) {}
 };
 
 /**
  * @class CreateClassException
  * @brief An exception class thrown when pluginlib is unable to create the class associated with a given plugin
  */
-class CreateClassException: public PluginlibException
+class CreateClassException : public PluginlibException
 {
-  public:
-    CreateClassException(const std::string error_desc) : PluginlibException(error_desc) {}
+public:
+  CreateClassException(const std::string error_desc)
+  : PluginlibException(error_desc) {}
 };
 
 

--- a/test/test_base.h
+++ b/test/test_base.h
@@ -3,15 +3,15 @@
 
 namespace test_base
 {
-  class Fubar
-  {
-  public:
-    virtual void initialize(double foo) = 0;
-    virtual double result() = 0;
-    virtual ~Fubar(){}
+class Fubar
+{
+public:
+  virtual void initialize(double foo) = 0;
+  virtual double result() = 0;
+  virtual ~Fubar() {}
 
-  protected:
-    Fubar(){}
-  };
+protected:
+  Fubar() {}
 };
+}
 #endif

--- a/test/test_base.h
+++ b/test/test_base.h
@@ -1,5 +1,34 @@
-#ifndef PLUGINLIB_TEST_BASE_H_
-#define PLUGINLIB_TEST_BASE_H_
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TEST_BASE_H_
+#define TEST_BASE_H_
 
 namespace test_base
 {
@@ -13,5 +42,5 @@ public:
 protected:
   Fubar() {}
 };
-}
-#endif
+}  // namespace test_base
+#endif  // TEST_BASE_H_

--- a/test/test_plugins.cpp
+++ b/test/test_plugins.cpp
@@ -1,6 +1,35 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <pluginlib/class_list_macros.h>
-#include "test_base.h"
-#include "test_plugins.h"
+#include "test_base.h"  // NOLINT
+#include "test_plugins.h"  // NOLINT
 
 PLUGINLIB_DECLARE_CLASS(pluginlib, foo, test_plugins::Foo, test_base::Fubar)
 PLUGINLIB_DECLARE_CLASS(pluginlib, bar, test_plugins::Bar, test_base::Fubar)

--- a/test/test_plugins.h
+++ b/test/test_plugins.h
@@ -1,7 +1,38 @@
-#ifndef PLUGINLIB_TEST_PLUGINS_H_
-#define PLUGINLIB_TEST_PLUGINS_H_
-#include "test_base.h"
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TEST_PLUGINS_H_
+#define TEST_PLUGINS_H_
+
 #include <cmath>
+
+#include "test_base.h"  // NOLINT
 
 namespace test_plugins
 {
@@ -46,7 +77,6 @@ public:
 
 private:
   double foo_;
-
 };
-}
-#endif
+}  // namespace test_plugins
+#endif  // TEST_PLUGINS_H_

--- a/test/test_plugins.h
+++ b/test/test_plugins.h
@@ -8,7 +8,7 @@ namespace test_plugins
 class Bar : public test_base::Fubar
 {
 public:
-  Bar(){}
+  Bar() {}
 
   void initialize(double foo)
   {
@@ -32,7 +32,7 @@ private:
 class Foo : public test_base::Fubar
 {
 public:
-  Foo(){}
+  Foo() {}
 
   void initialize(double foo)
   {
@@ -48,5 +48,5 @@ private:
   double foo_;
 
 };
-};
+}
 #endif

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -76,7 +76,7 @@ TEST(PluginlibUniquePtrTest, createUniqueInstanceAndUnloadLibrary) {
   }
 
   ROS_INFO("Checking if plugin is loaded with isClassLoaded...");
-  if (pl.isClassLoaded("pluginlib/foo") ) {
+  if (pl.isClassLoaded("pluginlib/foo")) {
     ROS_INFO("Class is loaded");
   } else {
     FAIL() << "Library containing class should be loaded but isn't.";

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -1,6 +1,37 @@
-#include <pluginlib/class_loader.h>
-#include "test_base.h"
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <gtest/gtest.h>
+
+#include <pluginlib/class_loader.h>
+
+#include "test_base.h"  // NOLINT
 
 TEST(PluginlibUniquePtrTest, unknownPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -2,80 +2,67 @@
 #include "test_base.h"
 #include <gtest/gtest.h>
 
-TEST(PluginlibUniquePtrTest, unknownPlugin)
-{
+TEST(PluginlibUniquePtrTest, unknownPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");
-  ASSERT_THROW(test_loader.createUniqueInstance("pluginlib/foobar"), pluginlib::LibraryLoadException);
+  ASSERT_THROW(test_loader.createUniqueInstance("pluginlib/foobar"),
+    pluginlib::LibraryLoadException);
 }
 
 
-TEST(PluginlibUniquePtrTest, misspelledPlugin)
-{
+TEST(PluginlibUniquePtrTest, misspelledPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> bad_test_loader("pluginlib", "test_base::Fuba");
-  ASSERT_THROW(bad_test_loader.createUniqueInstance("pluginlib/foo"), pluginlib::LibraryLoadException);
+  ASSERT_THROW(bad_test_loader.createUniqueInstance(
+      "pluginlib/foo"), pluginlib::LibraryLoadException);
 }
 
-TEST(PluginlibTest, brokenPlugin)
-{
+TEST(PluginlibTest, brokenPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");
   ASSERT_THROW(test_loader.createUniqueInstance("pluginlib/none"), pluginlib::PluginlibException);
 }
 
-TEST(PluginlibUniquePtrTest, workingPlugin)
-{
+TEST(PluginlibUniquePtrTest, workingPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");
 
-  try
-  {
+  try {
     pluginlib::UniquePtr<test_base::Fubar> foo = test_loader.createUniqueInstance("pluginlib/foo");
     foo->initialize(10.0);
-    EXPECT_EQ(foo->result(),100.0);
-  }
-  catch(pluginlib::PluginlibException& ex)
-  {
+    EXPECT_EQ(foo->result(), 100.0);
+  } catch (pluginlib::PluginlibException & ex) {
     FAIL() << "Throwing exception: " << ex.what();
     return;
-  }
-  catch(...)
-  {
+  } catch (...) {
     FAIL() << "Uncaught exception";
   }
 }
 
-TEST(PluginlibUniquePtrTest, createUniqueInstanceAndUnloadLibrary)
-{
-  ROS_INFO( "Making the ClassLoader..." );
+TEST(PluginlibUniquePtrTest, createUniqueInstanceAndUnloadLibrary) {
+  ROS_INFO("Making the ClassLoader...");
   pluginlib::ClassLoader<test_base::Fubar> pl("pluginlib", "test_base::Fubar");
 
-  ROS_INFO( "Instantiating plugin..." );
+  ROS_INFO("Instantiating plugin...");
   {
-   pluginlib::UniquePtr<test_base::Fubar> inst = pl.createUniqueInstance("pluginlib/foo");
+    pluginlib::UniquePtr<test_base::Fubar> inst = pl.createUniqueInstance("pluginlib/foo");
   }
 
-  ROS_INFO( "Checking if plugin is loaded with isClassLoaded..." );
-  if( pl.isClassLoaded( "pluginlib/foo" ) )
-    ROS_INFO( "Class is loaded" );
-  else
-  {
-    FAIL() <<  "Library containing class should be loaded but isn't.";
+  ROS_INFO("Checking if plugin is loaded with isClassLoaded...");
+  if (pl.isClassLoaded("pluginlib/foo") ) {
+    ROS_INFO("Class is loaded");
+  } else {
+    FAIL() << "Library containing class should be loaded but isn't.";
   }
 
-  ROS_INFO( "Trying to unload class with unloadLibraryForClass..." );
-  try
-  {
+  ROS_INFO("Trying to unload class with unloadLibraryForClass...");
+  try {
     pl.unloadLibraryForClass("pluginlib/foo");
-  }
-  catch(pluginlib::PluginlibException& e)
-  {
+  } catch (pluginlib::PluginlibException & e) {
     FAIL() << "Could not unload library when I should be able to.";
   }
-  ROS_INFO( "Done." );
+  ROS_INFO("Done.");
 }
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-
-

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -80,7 +80,7 @@ TEST(PluginlibTest, createUnmanagedInstanceAndUnloadLibrary) {
   delete inst;
 
   ROS_INFO("Checking if plugin is loaded with isClassLoaded...");
-  if (pl.isClassLoaded("pluginlib/foo") ) {
+  if (pl.isClassLoaded("pluginlib/foo")) {
     ROS_INFO("Class is loaded");
   } else {
     FAIL() << "Library containing class should be loaded but isn't.";
@@ -104,7 +104,7 @@ TEST(PluginlibTest, createManagedInstanceAndUnloadLibrary) {
   }
 
   ROS_INFO("Checking if plugin is loaded with isClassLoaded...");
-  if (pl.isClassLoaded("pluginlib/foo") ) {
+  if (pl.isClassLoaded("pluginlib/foo")) {
     ROS_INFO("Class is loaded");
   } else {
     FAIL() << "Library containing class should be loaded but isn't.";

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -1,6 +1,37 @@
-#include <pluginlib/class_loader.h>
-#include "test_base.h"
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <gtest/gtest.h>
+
+#include <pluginlib/class_loader.h>
+
+#include "test_base.h"  // NOLINT
 
 TEST(PluginlibTest, unknownPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -2,118 +2,97 @@
 #include "test_base.h"
 #include <gtest/gtest.h>
 
-TEST(PluginlibTest, unknownPlugin)
-{
+TEST(PluginlibTest, unknownPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");
   ASSERT_THROW(test_loader.createInstance("pluginlib/foobar"), pluginlib::LibraryLoadException);
 }
 
-TEST(PluginlibTest, misspelledPlugin)
-{
+TEST(PluginlibTest, misspelledPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> bad_test_loader("pluginlib", "test_base::Fuba");
   ASSERT_THROW(bad_test_loader.createInstance("pluginlib/foo"), pluginlib::LibraryLoadException);
 }
 
-TEST(PluginlibTest, invalidPackage)
-{
-  ASSERT_THROW(pluginlib::ClassLoader<test_base::Fubar>("pluginlib_bad", "test_base::Fubar"), pluginlib::ClassLoaderException);
+TEST(PluginlibTest, invalidPackage) {
+  ASSERT_THROW(pluginlib::ClassLoader<test_base::Fubar>("pluginlib_bad",
+    "test_base::Fubar"),
+    pluginlib::ClassLoaderException);
 }
 
-TEST(PluginlibTest, brokenPlugin)
-{
+TEST(PluginlibTest, brokenPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");
   ASSERT_THROW(test_loader.createInstance("pluginlib/none"), pluginlib::PluginlibException);
 }
 
-TEST(PluginlibTest, workingPlugin)
-{
+TEST(PluginlibTest, workingPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");
 
-  try
-  {
+  try {
     boost::shared_ptr<test_base::Fubar> foo = test_loader.createInstance("pluginlib/foo");
     foo->initialize(10.0);
-    EXPECT_EQ(foo->result(),100.0);
-  }
-  catch(pluginlib::PluginlibException& ex)
-  {
+    EXPECT_EQ(foo->result(), 100.0);
+  } catch (pluginlib::PluginlibException & ex) {
     FAIL() << "Throwing exception: " << ex.what();
     return;
-  }
-  catch(...)
-  {
+  } catch (...) {
     FAIL() << "Uncaught exception";
   }
 }
 
-TEST(PluginlibTest, createUnmanagedInstanceAndUnloadLibrary)
-{
-  ROS_INFO( "Making the ClassLoader..." );
+TEST(PluginlibTest, createUnmanagedInstanceAndUnloadLibrary) {
+  ROS_INFO("Making the ClassLoader...");
   pluginlib::ClassLoader<test_base::Fubar> pl("pluginlib", "test_base::Fubar");
 
-  ROS_INFO( "Instantiating plugin..." );
-  test_base::Fubar *inst = pl.createUnmanagedInstance("pluginlib/foo");
+  ROS_INFO("Instantiating plugin...");
+  test_base::Fubar * inst = pl.createUnmanagedInstance("pluginlib/foo");
 
-  ROS_INFO( "Deleting plugin..." );
+  ROS_INFO("Deleting plugin...");
   delete inst;
 
-  ROS_INFO( "Checking if plugin is loaded with isClassLoaded..." );
-  if( pl.isClassLoaded( "pluginlib/foo" ) )
-    ROS_INFO( "Class is loaded" );
-  else
-  {
-    FAIL() <<  "Library containing class should be loaded but isn't.";
+  ROS_INFO("Checking if plugin is loaded with isClassLoaded...");
+  if (pl.isClassLoaded("pluginlib/foo") ) {
+    ROS_INFO("Class is loaded");
+  } else {
+    FAIL() << "Library containing class should be loaded but isn't.";
   }
-  ROS_INFO( "Trying to unload class with unloadLibraryForClass..." );
-  try
-  {
+  ROS_INFO("Trying to unload class with unloadLibraryForClass...");
+  try {
     pl.unloadLibraryForClass("pluginlib/foo");
-  }
-  catch(pluginlib::PluginlibException& e)
-  {
+  } catch (pluginlib::PluginlibException & e) {
     FAIL() << "Could not unload library when I should be able to.";
   }
-  ROS_INFO( "Done." );
+  ROS_INFO("Done.");
 }
 
-TEST(PluginlibTest, createManagedInstanceAndUnloadLibrary)
-{
-  ROS_INFO( "Making the ClassLoader..." );
+TEST(PluginlibTest, createManagedInstanceAndUnloadLibrary) {
+  ROS_INFO("Making the ClassLoader...");
   pluginlib::ClassLoader<test_base::Fubar> pl("pluginlib", "test_base::Fubar");
 
-  ROS_INFO( "Instantiating plugin..." );
+  ROS_INFO("Instantiating plugin...");
   {
     boost::shared_ptr<test_base::Fubar> inst = pl.createInstance("pluginlib/foo");
   }
 
-  ROS_INFO( "Checking if plugin is loaded with isClassLoaded..." );
-  if( pl.isClassLoaded( "pluginlib/foo" ) )
-    ROS_INFO( "Class is loaded" );
-  else
-  {
-    FAIL() <<  "Library containing class should be loaded but isn't.";
+  ROS_INFO("Checking if plugin is loaded with isClassLoaded...");
+  if (pl.isClassLoaded("pluginlib/foo") ) {
+    ROS_INFO("Class is loaded");
+  } else {
+    FAIL() << "Library containing class should be loaded but isn't.";
   }
 
-  ROS_INFO( "Trying to unload class with unloadLibraryForClass..." );
-  try
-  {
+  ROS_INFO("Trying to unload class with unloadLibraryForClass...");
+  try {
     pl.unloadLibraryForClass("pluginlib/foo");
-  }
-  catch(pluginlib::PluginlibException& e)
-  {
+  } catch (pluginlib::PluginlibException & e) {
     FAIL() << "Could not unload library when I should be able to.";
   }
-  ROS_INFO( "Done." );
+  ROS_INFO("Done.");
 }
 
-TEST(PluginlibTest, brokenXML)
-{
-  try
-  {
-    pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar", "plugin_test");
-  }
-  catch(pluginlib::InvalidXMLException& ex)
-  {
+TEST(PluginlibTest, brokenXML) {
+  try {
+    pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar",
+      "plugin_test");
+  } catch (pluginlib::InvalidXMLException & ex) {
     SUCCEED();
     return;
   }
@@ -122,9 +101,8 @@ TEST(PluginlibTest, brokenXML)
 }
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-
-


### PR DESCRIPTION
I did this by running `ament_uncrustify` and `ament_cpplint` over the project. The idea of this pr is to get the style of the project close to what we'd like to have even if we cannot easily add automated tests to ensure the style does not diverge. In the future if we can add these tests, the diff will be smaller due to this pr.

I went through and tried to ensure there were no API or ABI changes, but the reviewers should watch closely for these.

I will make another pr to melodic-devel with ABI breaking style changes (using `explicit` on single argument constructors for example).