### PR TITLE
Remove and replace boost usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,26 +2,28 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pluginlib)
 
 find_package(catkin REQUIRED COMPONENTS class_loader rosconsole roslib cmake_modules)
-find_package(Boost REQUIRED COMPONENTS filesystem system)
+find_package(Boost REQUIRED)  # should be removed when deprecated createInstance is removed
 find_package(TinyXML2 REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS class_loader rosconsole roslib
-  DEPENDS Boost TinyXML2
+  DEPENDS
+    Boost  # should be removed when deprecated createInstance is removed
+    TinyXML2
 )
 
 install(DIRECTORY include/pluginlib/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${TinyXML2_INCLUDE_DIRS})
+  include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML2_INCLUDE_DIRS})
 
   add_library(test_plugins EXCLUDE_FROM_ALL SHARED test/test_plugins.cpp)
 
   catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}_utest)
-    target_link_libraries(${PROJECT_NAME}_utest ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME}_utest ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES})
     add_dependencies(${PROJECT_NAME}_utest test_plugins)
   endif()
 
@@ -30,7 +32,7 @@ if(CATKIN_ENABLE_TESTING)
   if(COMPILER_SUPPORTS_CXX11)
     catkin_add_gtest(${PROJECT_NAME}_unique_ptr_test test/unique_ptr_test.cpp)
     if(TARGET ${PROJECT_NAME}_unique_ptr_test)
-      target_link_libraries(${PROJECT_NAME}_unique_ptr_test ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+      target_link_libraries(${PROJECT_NAME}_unique_ptr_test ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES})
       set_target_properties(${PROJECT_NAME}_unique_ptr_test PROPERTIES COMPILE_FLAGS -std=c++11 LINK_FLAGS -std=c++11)
       add_dependencies(${PROJECT_NAME}_unique_ptr_test test_plugins)
     endif()

--- a/include/pluginlib/class_loader.hpp
+++ b/include/pluginlib/class_loader.hpp
@@ -34,7 +34,11 @@
 #include <string>
 #include <vector>
 
-#include "boost/algorithm/string.hpp"
+#if __cplusplus >= 201103L
+# include <memory>
+#endif
+
+#include <boost/shared_ptr.hpp>
 #include "class_loader/multi_library_class_loader.h"
 #include "pluginlib/class_desc.hpp"
 #include "pluginlib/class_loader_base.hpp"
@@ -89,6 +93,7 @@ public:
     const std::string & lookup_name,
     bool auto_load = true);
 
+#if __cplusplus >= 201103L
   /// Creates an instance of a desired class.
   /**
    * Implicitly calls loadLibraryForClass() to increment the library counter.
@@ -102,6 +107,15 @@ public:
    *   instantiated.
    * @return An instance of the class
    */
+  std::shared_ptr<T> createSharedInstance(const std::string & lookup_name);
+#endif
+
+  /// Creates an instance of a desired class.
+  /**
+   * Deprecated, use createSharedInstance() instead.
+   * Same as createSharedInstance() except it returns a boost::shared_ptr.
+   */
+  __attribute__((deprecated))
   boost::shared_ptr<T> createInstance(const std::string & lookup_name);
 
 #if __cplusplus >= 201103L

--- a/include/pluginlib/class_loader.hpp
+++ b/include/pluginlib/class_loader.hpp
@@ -43,12 +43,6 @@
 #include "ros/package.h"
 #include "tinyxml2.h"  // NOLINT
 
-// Note: pluginlib has traditionally utilized a "lookup name" for classes that does not match its
-// real C++ name.
-// This was done due to limitations of how pluginlib was implemented.
-// As of version 1.9, a lookup name is no longer necessary and an attempt to the merge two concepts
-// is underway.
-
 namespace pluginlib
 {
 

--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -154,6 +154,15 @@ T * ClassLoader<T>::createClassInstance(const std::string & lookup_name, bool au
   }
 }
 
+#if __cplusplus >= 201103L
+template<class T>
+std::shared_ptr<T> ClassLoader<T>::createSharedInstance(const std::string & lookup_name)
+/***************************************************************************/
+{
+  return createUniqueInstance(lookup_name);
+}
+#endif
+
 template<class T>
 boost::shared_ptr<T> ClassLoader<T>::createInstance(const std::string & lookup_name)
 /***************************************************************************/

--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -47,36 +47,35 @@
 #include <utility>
 #include <vector>
 
-#include "boost/algorithm/string.hpp"
-#include "boost/bind.hpp"
-#include "boost/filesystem.hpp"
-#include "boost/foreach.hpp"
 #include "class_loader/class_loader.h"
 
 #include "ros/package.h"
 
 #include "./class_loader.hpp"
+#include "./impl/filesystem_helper.hpp"
+#include "./impl/split.hpp"
 
 #ifdef _WIN32
-const std::string os_pathsep(";");  // NOLINT
+#define CLASS_LOADER_IMPL_OS_PATHSEP ";"
 #else
-const std::string os_pathsep(":");  // NOLINT
+#define CLASS_LOADER_IMPL_OS_PATHSEP ":"
 #endif
 
 namespace
 {
+
 std::vector<std::string> catkinFindLib()
 {
   std::vector<std::string> lib_paths;
   const char * env = std::getenv("CMAKE_PREFIX_PATH");
   if (env) {
     std::string env_catkin_prefix_paths(env);
-    std::vector<std::string> catkin_prefix_paths;
-    boost::split(catkin_prefix_paths, env_catkin_prefix_paths, boost::is_any_of(os_pathsep));
-    BOOST_FOREACH(std::string catkin_prefix_path, catkin_prefix_paths) {
-      boost::filesystem::path path(catkin_prefix_path);
-      boost::filesystem::path lib("lib");
-      lib_paths.push_back((path / lib).string());
+    std::vector<std::string> catkin_prefix_paths =
+      pluginlib::impl::split(env_catkin_prefix_paths, CLASS_LOADER_IMPL_OS_PATHSEP);
+    for(std::string catkin_prefix_path : catkin_prefix_paths) {
+      pluginlib::impl::fs::path prefix(catkin_prefix_path);
+      pluginlib::impl::fs::path lib("lib");
+      lib_paths.push_back((prefix / lib).string());
     }
   }
   return lib_paths;
@@ -86,6 +85,7 @@ std::vector<std::string> catkinFindLib()
 
 namespace pluginlib
 {
+
 template<class T>
 ClassLoader<T>::ClassLoader(
   std::string package, std::string base_class, std::string attrib_name,
@@ -426,7 +426,7 @@ std::string ClassLoader<T>::getClassLibraryPath(const std::string & lookup_name)
     it++)
   {
     ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Checking path %s ", it->c_str());
-    if (boost::filesystem::exists(*it)) {
+    if (pluginlib::impl::fs::exists(*it)) {
       ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Library %s found at explicit path %s.",
         library_name.c_str(), it->c_str());
       return *it;
@@ -484,9 +484,8 @@ std::string ClassLoader<T>::getName(const std::string & lookup_name)
 /***************************************************************************/
 {
   // remove the package name to get the raw plugin name
-  std::vector<std::string> split;
-  boost::split(split, lookup_name, boost::is_any_of("/:"));
-  return split.back();
+  std::vector<std::string> result = pluginlib::impl::split(lookup_name, "/|:");
+  return result.back();
 }
 
 template<class T>
@@ -510,20 +509,16 @@ ClassLoader<T>::getPackageFromPluginXMLFilePath(const std::string & plugin_xml_f
   // 2. Extract name of package from package.xml
 
   std::string package_name;
-  boost::filesystem::path p(plugin_xml_file_path);
-  boost::filesystem::path parent = p.parent_path();
+  pluginlib::impl::fs::path p(plugin_xml_file_path);
+  pluginlib::impl::fs::path parent = p.parent_path();
 
   // Figure out exactly which package the passed XML file is exported by.
   while (true) {
-    if (boost::filesystem::exists(parent / "package.xml")) {
-      std::string package_file_path = (boost::filesystem::path(parent / "package.xml")).string();
+    if (pluginlib::impl::fs::exists(parent / "package.xml")) {
+      std::string package_file_path = (parent / "package.xml").string();
       return extractPackageNameFromPackageXML(package_file_path);
-    } else if (boost::filesystem::exists(parent / "manifest.xml")) {
-#if BOOST_FILESYSTEM_VERSION >= 3
+    } else if (pluginlib::impl::fs::exists(parent / "manifest.xml")) {
       std::string package = parent.filename().string();
-#else
-      std::string package = parent.filename();
-#endif
       std::string package_path = ros::package::getPath(package);
 
       // package_path is a substr of passed plugin xml path
@@ -549,11 +544,7 @@ template<class T>
 std::string ClassLoader<T>::getPathSeparator()
 /***************************************************************************/
 {
-#if BOOST_FILESYSTEM_VERSION >= 3
-  return boost::filesystem::path("/").native();
-#else
-  return boost::filesystem::path("/").external_file_string();
-#endif
+  return std::string(1, pluginlib::impl::fs::path::preferred_separator);
 }
 
 
@@ -594,7 +585,7 @@ template<class T>
 std::string ClassLoader<T>::joinPaths(const std::string & path1, const std::string & path2)
 /***************************************************************************/
 {
-  boost::filesystem::path p1(path1);
+  pluginlib::impl::fs::path p1(path1);
   return (p1 / path2).string();
 }
 

--- a/include/pluginlib/impl/filesystem_helper.hpp
+++ b/include/pluginlib/impl/filesystem_helper.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// Includes std::filesystem and aliases the namespace to `pluginlib::impl::fs`.
+/**
+ * If std::filesystem is not available the necessary functions are emulated.
+ */
+
+#ifndef SOMETHING_FILESYSTEM_HELPER
+#define SOMETHING_FILESYSTEM_HELPER
+
+#if defined(__has_include)
+#if __has_include(<filesystem>)
+# include <filesystem>
+
+namespace pluginlib
+{
+namespace impl
+{
+namespace fs = std::filesystem;
+}  // namespace impl
+}  // namespace pluginlib
+
+#define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+#elif __has_include(<experimental/filesystem>)
+# include <experimental/filesystem>
+
+namespace pluginlib
+{
+namespace impl
+{
+namespace fs = std::experimental::filesystem;
+}  // namespace impl
+}  // namespace pluginlib
+
+#define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+#endif
+#endif
+
+// The standard library does not provide it, so emulate it.
+#ifndef PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+
+#include <string>
+
+#ifdef _WIN32
+#define CLASS_LOADER_IMPL_OS_DIRSEP '\\'
+#else
+#define CLASS_LOADER_IMPL_OS_DIRSEP '/'
+#endif
+
+#ifdef _WIN32
+  #include <io.h>
+  #define access _access_s
+#else
+  #include <unistd.h>
+#endif
+
+#include "./split.hpp"
+
+namespace pluginlib
+{
+namespace impl
+{
+namespace fs
+{
+
+class path
+{
+public:
+  static constexpr char preferred_separator = CLASS_LOADER_IMPL_OS_DIRSEP;
+
+  path()
+  : path("")
+  {}
+
+  path(const std::string & p)  // NOLINT(runtime/explicit): this is a conversion constructor
+  : path_(p), path_as_vector_(split(p, std::string(1, preferred_separator)))
+  {}
+
+  std::string string() const
+  {
+    return path_;
+  }
+
+  bool exists() const
+  {
+    return access(path_.c_str(), 0) == 0;
+  }
+
+  std::vector<std::string>::const_iterator cbegin() const
+  {
+    return path_as_vector_.cbegin();
+  }
+
+  std::vector<std::string>::const_iterator cend() const
+  {
+    return path_as_vector_.cend();
+  }
+
+  path parent_path() const
+  {
+    path parent("");
+    for (auto it = this->cbegin(); it != --this->cend(); ++it) {
+      parent /= *it;
+    }
+    return parent;
+  }
+
+  path filename() const
+  {
+    return path_.empty() ? path() : *--this->cend();
+  }
+
+  path & operator/(const std::string & other)
+  {
+    this->path_ += CLASS_LOADER_IMPL_OS_DIRSEP + other;
+    this->path_as_vector_.push_back(other);
+    return *this;
+  }
+
+  path & operator/=(const std::string & other)
+  {
+    this->operator/(other);
+    return *this;
+  }
+
+  path & operator/(const path & other)
+  {
+    this->path_ += CLASS_LOADER_IMPL_OS_DIRSEP + other.string();
+    this->path_as_vector_.push_back(other.string()); 
+    return *this;
+  }
+
+  path & operator/=(const path & other)
+  {
+    this->operator/(other);
+    return *this;
+  }
+
+private:
+  std::string path_;
+  std::vector<std::string> path_as_vector_;
+};
+
+bool exists(const path & path_to_check)
+{
+  return path_to_check.exists();
+}
+
+#undef CLASS_LOADER_IMPL_OS_DIRSEP
+
+}  // namespace fs
+}  // namespace impl
+}  // namespace pluginlib
+
+#endif  // PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+
+#undef PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+
+#endif  // SOMETHING_FILESYSTEM_HELPER

--- a/include/pluginlib/impl/split.hpp
+++ b/include/pluginlib/impl/split.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SOMETHING_SPLIT
+#define SOMETHING_SPLIT
+
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace pluginlib
+{
+namespace impl
+{
+
+std::vector<std::string>
+split(const std::string & input, const std::string & regex) {
+  std::regex re(regex);
+  // the -1 will cause this to return the stuff between the matches, see the submatch argument:
+  //   http://en.cppreference.com/w/cpp/regex/regex_token_iterator/regex_token_iterator
+  std::sregex_token_iterator first(input.begin(), input.end(), re, -1);
+  std::sregex_token_iterator last;
+  return {first, last};  // vector will copy from first to last
+}
+
+}  // namespace impl
+}  // namespace pluginlib
+
+#endif  // SOMETHING_SPLIT

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -58,7 +58,7 @@ TEST(PluginlibTest, workingPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");
 
   try {
-    boost::shared_ptr<test_base::Fubar> foo = test_loader.createInstance("pluginlib/foo");
+    std::shared_ptr<test_base::Fubar> foo = test_loader.createInstance("pluginlib/foo");
     foo->initialize(10.0);
     EXPECT_EQ(100.0, foo->result());
   } catch (pluginlib::PluginlibException & ex) {
@@ -100,7 +100,7 @@ TEST(PluginlibTest, createManagedInstanceAndUnloadLibrary) {
 
   ROS_INFO("Instantiating plugin...");
   {
-    boost::shared_ptr<test_base::Fubar> inst = pl.createInstance("pluginlib/foo");
+    std::shared_ptr<test_base::Fubar> inst = pl.createInstance("pluginlib/foo");
   }
 
   ROS_INFO("Checking if plugin is loaded with isClassLoaded...");


### PR DESCRIPTION
This pr removes all uses of boost and replaces them with either c++11 alternatives.

In the case of boost::filesystem, it is replaced with standard library calls to std::filesystem when it is available, or it emulates the subset of std::filesystem required when it is not.

For now this pr includes some of the style commits that are in currently open pr's. I will rebase it when those are merged.

There are still a few things I need to test out before I put this in review, but I'm opening it to get CI going and for visibility.

Also, this removes the version of the function that returns a `boost::shared_ptr` without deprecating it first. I'm not sure if we can do that, but in other places in ROS we've replaced this and just made a typedef for people to use to ease the migration, though it would cause everyone to update their code. I guess it's also possible to retroactively deprecate it in Lunar to give some warning that it will be gone in Melodic, though I'm open to suggestion about how to do that.