### PR TITLE
remove nolint and use relative paths

### DIFF
--- a/include/pluginlib/class_loader.h
+++ b/include/pluginlib/class_loader.h
@@ -357,6 +357,6 @@ private:
 }  // namespace pluginlib
 
 // Note: The implementation of the methods is in a separate file for clarity.
-#include "class_loader_imp.h"  // NOLINT
+#include "./class_loader_imp.h"
 
 #endif  // PLUGINLIB__CLASS_LOADER_H_

--- a/test/test_plugins.cpp
+++ b/test/test_plugins.cpp
@@ -28,8 +28,8 @@
  */
 
 #include <pluginlib/class_list_macros.h>
-#include "test_base.h"  // NOLINT
-#include "test_plugins.h"  // NOLINT
+#include "./test_base.h"
+#include "./test_plugins.h"
 
 PLUGINLIB_DECLARE_CLASS(pluginlib, foo, test_plugins::Foo, test_base::Fubar)
 PLUGINLIB_DECLARE_CLASS(pluginlib, bar, test_plugins::Bar, test_base::Fubar)

--- a/test/test_plugins.h
+++ b/test/test_plugins.h
@@ -32,7 +32,7 @@
 
 #include <cmath>
 
-#include "test_base.h"  // NOLINT
+#include "./test_base.h"
 
 namespace test_plugins
 {

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -31,7 +31,7 @@
 
 #include <pluginlib/class_loader.h>
 
-#include "test_base.h"  // NOLINT
+#include "./test_base.h"
 
 TEST(PluginlibUniquePtrTest, unknownPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -31,7 +31,7 @@
 
 #include <pluginlib/class_loader.h>
 
-#include "test_base.h"  // NOLINT
+#include "./test_base.h"
 
 TEST(PluginlibTest, unknownPlugin) {
   pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar");


### PR DESCRIPTION
fix easily fixable linter errors. Needs to be forward ported to melodic-devel