### PR TITLE
Continue loading classes on error

### DIFF
--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -280,9 +280,7 @@ std::map<std::string, ClassDesc> ClassLoader<T>::determineAvailableClasses(
   {
     try {
       processSingleXMLPluginFile(*it, classes_available);
-    }
-    catch(const pluginlib::InvalidXMLException &e)
-    {
+    } catch (const pluginlib::InvalidXMLException & e) {
       ROS_ERROR_NAMED("pluginlib.ClassLoader",
         "Skipped loading plugin with error: %s.",
         e.what());
@@ -653,8 +651,8 @@ void ClassLoader<T>::processSingleXMLPluginFile(
   tinyxml2::XMLElement * config = document.RootElement();
   if (NULL == config) {
     throw pluginlib::InvalidXMLException(
-              "XML Document '" + xml_file +
-              "'has no Root Element. This likely means the XML is malformed or missing.");
+            "XML Document '" + xml_file +
+            "'has no Root Element. This likely means the XML is malformed or missing.");
     return;
   }
   if (!(strcmp(config->Value(), "library") == 0 ||

--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -652,14 +652,14 @@ void ClassLoader<T>::processSingleXMLPluginFile(
   if (NULL == config) {
     throw pluginlib::InvalidXMLException(
             "XML Document '" + xml_file +
-            "'has no Root Element. This likely means the XML is malformed or missing.");
+            "' has no Root Element. This likely means the XML is malformed or missing.");
     return;
   }
   if (!(strcmp(config->Value(), "library") == 0 ||
     strcmp(config->Value(), "class_libraries") == 0))
   {
     throw pluginlib::InvalidXMLException(
-            "The XML document '" + xml_file + "'given to add must have either \"library\" or "
+            "The XML document '" + xml_file + "' given to add must have either \"library\" or "
             "\"class_libraries\" as the root tag");
     return;
   }

--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -653,17 +653,16 @@ void ClassLoader<T>::processSingleXMLPluginFile(
   tinyxml2::XMLElement * config = document.RootElement();
   if (NULL == config) {
     throw pluginlib::InvalidXMLException(
-            "XML Document has no Root Element. This likely means the XML is malformed or missing.",
-            xml_file);
+              "XML Document '" + xml_file +
+              "'has no Root Element. This likely means the XML is malformed or missing.");
     return;
   }
   if (!(strcmp(config->Value(), "library") == 0 ||
     strcmp(config->Value(), "class_libraries") == 0))
   {
     throw pluginlib::InvalidXMLException(
-            "The XML document given to add must have either \"library\" or "
-            "\"class_libraries\" as the root tag",
-            xml_file);
+            "The XML document '" + xml_file + "'given to add must have either \"library\" or "
+            "\"class_libraries\" as the root tag");
     return;
   }
   // Step into the filter list if necessary

--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -278,7 +278,15 @@ std::map<std::string, ClassDesc> ClassLoader<T>::determineAvailableClasses(
   for (std::vector<std::string>::const_iterator it = plugin_xml_paths.begin();
     it != plugin_xml_paths.end(); ++it)
   {
-    processSingleXMLPluginFile(*it, classes_available);
+    try {
+      processSingleXMLPluginFile(*it, classes_available);
+    }
+    catch(const pluginlib::InvalidXMLException &e)
+    {
+      ROS_ERROR_NAMED("pluginlib.ClassLoader",
+        "Skipped loading plugin with error: %s.",
+        e.what());
+    }
   }
 
   ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Exiting determineAvailableClasses()...");
@@ -645,7 +653,8 @@ void ClassLoader<T>::processSingleXMLPluginFile(
   tinyxml2::XMLElement * config = document.RootElement();
   if (NULL == config) {
     throw pluginlib::InvalidXMLException(
-            "XML Document has no Root Element. This likely means the XML is malformed or missing.");
+            "XML Document has no Root Element. This likely means the XML is malformed or missing.",
+            xml_file);
     return;
   }
   if (!(strcmp(config->Value(), "library") == 0 ||
@@ -653,7 +662,8 @@ void ClassLoader<T>::processSingleXMLPluginFile(
   {
     throw pluginlib::InvalidXMLException(
             "The XML document given to add must have either \"library\" or "
-            "\"class_libraries\" as the root tag");
+            "\"class_libraries\" as the root tag",
+            xml_file);
     return;
   }
   // Step into the filter list if necessary

--- a/include/pluginlib/exceptions.hpp
+++ b/include/pluginlib/exceptions.hpp
@@ -58,6 +58,8 @@ class InvalidXMLException : public PluginlibException
 public:
   InvalidXMLException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : PluginlibException(error_desc) {}
+  InvalidXMLException(const std::string error_desc, const std::string xml_path)  // NOLINT(runtime/explicit)
+  : PluginlibException(error_desc + " at " + xml_path) {}
 };
 
 /// An exception class thrown when pluginlib is unable to load the library associated with a given plugin.

--- a/include/pluginlib/exceptions.hpp
+++ b/include/pluginlib/exceptions.hpp
@@ -58,8 +58,6 @@ class InvalidXMLException : public PluginlibException
 public:
   InvalidXMLException(const std::string error_desc)  // NOLINT(runtime/explicit)
   : PluginlibException(error_desc) {}
-  InvalidXMLException(const std::string error_desc, const std::string xml_path)  // NOLINT(runtime/explicit)
-  : PluginlibException(error_desc + " at " + xml_path) {}
 };
 
 /// An exception class thrown when pluginlib is unable to load the library associated with a given plugin.

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -123,7 +123,8 @@ TEST(PluginlibTest, brokenXML) {
   try {
     pluginlib::ClassLoader<test_base::Fubar> test_loader("pluginlib", "test_base::Fubar",
       "plugin_test");
-  } catch (pluginlib::InvalidXMLException & ex) {
+    test_loader.createInstance("pluginlib/foo");
+  } catch (pluginlib::PluginlibException & ex) {
     SUCCEED();
     return;
   }


### PR DESCRIPTION
pluginlib functions stop on error on loading classes, therefore if there is only one invalid or missing plugin xml, all pluginlib functions does not work.
In this pull request, I added `try-catch` on loading each xml file and let this procedure continue on error with printing error message.

Currently, for example, `gmapping` package has missing pluginlib xml which fails nodelet working:

```bash
$ sudo apt install ros-kinetic-gmapping ros-kinetic-nodelet  # using shadow-fixed repos
$ source /opt/ros/kinetic/setup.bash
$ roscore &
$ rosrun nodelet nodelet manager
terminate called after throwing an instance of 'pluginlib::InvalidXMLException'
  what():  XML Document has no Root Element. This likely means the XML is malformed or missing.
Aborted
```

After the change from this pull request:

```bash
$ rosrun nodelet nodelet manager
[ERROR] [1510545753.431745765]: Skipped loading plugin with error: XML Document has no Root Element. This likely means the XML is malformed or missing. at /opt/ros/kinetic/share/gmapping/nodelet_plugins.xml.
[ INFO] [1510545753.436734671]: Initializing nodelet with 4 worker threads.
```
