### PR TITLE
[kinetic] Fix cpplint and lint_cmake errors 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CATKIN_ENABLE_TESTING)
   endif()
 
   include(CheckCXXCompilerFlag)
-  CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+  check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
   if(COMPILER_SUPPORTS_CXX11)
     catkin_add_gtest(${PROJECT_NAME}_unique_ptr_test test/unique_ptr_test.cpp)
     if(TARGET ${PROJECT_NAME}_unique_ptr_test)

--- a/include/pluginlib/class_loader.hpp
+++ b/include/pluginlib/class_loader.hpp
@@ -301,7 +301,7 @@ private:
   /// Get the standard path separator for the native OS (e.g. "/" on *nix, "\" on Windows).
   std::string getPathSeparator();
 
-  /// Given a package name, return the path where rosbuild build system thinks plugins are installed.
+  /// Given a package name, return the path where rosbuild thinks plugins are installed.
   std::string getROSBuildLibraryPath(const std::string & exporting_package_name);
 
   /// Get the package name from a path to a plugin XML file.

--- a/include/pluginlib/exceptions.hpp
+++ b/include/pluginlib/exceptions.hpp
@@ -49,7 +49,7 @@ public:
   : std::runtime_error(error_desc) {}
 };
 
-/// An exception class thrown when pluginlib is unable to load a plugin XML file.
+/// Thrown when pluginlib is unable to load a plugin XML file.
 /**
  * \class InvalidXMLException
  */
@@ -60,7 +60,7 @@ public:
   : PluginlibException(error_desc) {}
 };
 
-/// An exception class thrown when pluginlib is unable to load the library associated with a given plugin.
+/// Thrown when pluginlib is unable to load the library associated with a given plugin.
 /**
  * \class LibraryLoadException
  */
@@ -71,7 +71,7 @@ public:
   : PluginlibException(error_desc) {}
 };
 
-/// An exception class thrown when pluginlib is unable to instantiate a class loader.
+/// Thrown when pluginlib is unable to instantiate a class loader.
 /**
  * \class ClassLoaderException
  */
@@ -82,7 +82,7 @@ public:
   : PluginlibException(error_desc) {}
 };
 
-/// An exception class thrown when pluginlib is unable to unload the library associated with a given plugin.
+/// Thrown when pluginlib is unable to unload the library associated with a given plugin.
 /**
  * \class LibraryUnloadException
  */
@@ -93,7 +93,7 @@ public:
   : PluginlibException(error_desc) {}
 };
 
-/// An exception class thrown when pluginlib is unable to create the class associated with a given plugin.
+/// Thrown when pluginlib is unable to create the class associated with a given plugin.
 /**
  * \class CreateClassException
  */

--- a/test/test_plugins.cpp
+++ b/test/test_plugins.cpp
@@ -28,8 +28,8 @@
  */
 
 #include <pluginlib/class_list_macros.hpp>
-#include "./test_base.h"  // NOLINT
-#include "./test_plugins.h"  // NOLINT
+#include "./test_base.h"
+#include "test_plugins.h"  // NOLINT
 
 PLUGINLIB_EXPORT_CLASS(test_plugins::Foo, test_base::Fubar)
 PLUGINLIB_EXPORT_CLASS(test_plugins::Bar, test_base::Fubar)


### PR DESCRIPTION
```
Fix cpplint and lint_cmake errors (#84)

    * fix line length

    add back NOLINT on test header to avoid 'should include its header file' cpplint error

    * lint cmake
```