### PR TITLE
fix export of stdc++fs for GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,6 @@ find_package(tinyxml2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_ve
 
 ament_export_dependencies(ament_index_cpp class_loader tinyxml2)
 ament_export_include_directories(include)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  find_library(STD_CPP_FS_PATH stdc++fs)
-  message(STATUS "STD_CPP_FS_PATH: ${STD_CPP_FS_PATH}")
-  ament_export_libraries(${STD_CPP_FS_PATH})
-endif()
 
 # target_include_directories(plugin_tool PUBLIC
 #   include

--- a/pluginlib-extras.cmake
+++ b/pluginlib-extras.cmake
@@ -20,7 +20,7 @@ ament_register_extension("ament_package" "pluginlib"
 
 include("${pluginlib_DIR}/pluginlib_export_plugin_description_file.cmake")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_COMPILER_IS_GNUCXX)
   # this is needed to use the experimental/filesystem on Linux, but cannot be passed with
   # ament_export_libraries() because it is not absolute and cannot be found with find_library
   list(APPEND pluginlib_LIBRARIES stdc++fs)

--- a/pluginlib-extras.cmake
+++ b/pluginlib-extras.cmake
@@ -19,3 +19,9 @@ ament_register_extension("ament_package" "pluginlib"
   "pluginlib_package_hook.cmake")
 
 include("${pluginlib_DIR}/pluginlib_export_plugin_description_file.cmake")
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # this is needed to use the experimental/filesystem on Linux, but cannot be passed with
+  # ament_export_libraries() because it is not absolute and cannot be found with find_library
+  list(APPEND pluginlib_LIBRARIES stdc++fs)
+endif()


### PR DESCRIPTION
Connects to ros2/rviz#123

But can be reviewed, tested, and merged anytime (now).