### PR TITLE
Windows fix ups

### DIFF
--- a/include/pluginlib/class_loader.hpp
+++ b/include/pluginlib/class_loader.hpp
@@ -91,7 +91,8 @@ public:
    * \return An instance of the class
    * \deprecated use either createInstance() or createUnmanagedInstance()
    */
-  __attribute__((deprecated)) T * createClassInstance(
+  [[deprecated]]
+  T * createClassInstance(
     const std::string & lookup_name,
     bool auto_load = true);
 
@@ -117,7 +118,7 @@ public:
    * Deprecated, use createSharedInstance() instead.
    * Same as createSharedInstance() except it returns a boost::shared_ptr.
    */
-  __attribute__((deprecated))
+  [[deprecated]]
   boost::shared_ptr<T> createInstance(const std::string & lookup_name);
 #endif
 

--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -152,6 +152,7 @@ std::shared_ptr<T> ClassLoader<T>::createSharedInstance(const std::string & look
 }
 #endif
 
+#ifndef PLUGINLIB__DISABLE_BOOST_FUNCTIONS
 template<class T>
 boost::shared_ptr<T> ClassLoader<T>::createInstance(const std::string & lookup_name)
 /***************************************************************************/
@@ -184,6 +185,7 @@ boost::shared_ptr<T> ClassLoader<T>::createInstance(const std::string & lookup_n
     throw pluginlib::CreateClassException(ex.what());
   }
 }
+#endif
 
 #if __cplusplus >= 201103L
 template<class T>

--- a/pluginlib-extras.cmake
+++ b/pluginlib-extras.cmake
@@ -25,3 +25,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   # ament_export_libraries() because it is not absolute and cannot be found with find_library
   list(APPEND pluginlib_LIBRARIES stdc++fs)
 endif()
+
+# tinyxml2 exports a target, not normal library paths, so add it explicitly here
+find_package(tinyxml2 REQUIRED)  # provided either by the system or by tinyxml2_vendor
+if(TARGET tinyxml2)
+  list(APPEND pluginlib_LIBRARIES tinyxml2)
+else()
+  message(FATAL_ERROR "'tinyxml2' is unexpectedly not a target")
+endif()

--- a/pluginlib-extras.cmake
+++ b/pluginlib-extras.cmake
@@ -25,11 +25,3 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   # ament_export_libraries() because it is not absolute and cannot be found with find_library
   list(APPEND pluginlib_LIBRARIES stdc++fs)
 endif()
-
-# tinyxml2 exports a target, not normal library paths, so add it explicitly here
-find_package(tinyxml2 REQUIRED)  # provided either by the system or by tinyxml2_vendor
-if(TARGET tinyxml2)
-  list(APPEND pluginlib_LIBRARIES tinyxml2)
-else()
-  message(FATAL_ERROR "'tinyxml2' is unexpectedly not a target")
-endif()


### PR DESCRIPTION
These are just some fixes I found while testing rviz on Windows, CI:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3700)](http://ci.ros2.org/job/ci_linux/3700/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=866)](http://ci.ros2.org/job/ci_linux-aarch64/866/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3035)](http://ci.ros2.org/job/ci_osx/3035/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3798)](http://ci.ros2.org/job/ci_windows/3798/)