### PR TITLE
remove references to plugin_tool from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,18 +19,6 @@ find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_ve
 ament_export_dependencies(ament_index_cpp class_loader tinyxml2_vendor TinyXML2)
 ament_export_include_directories(include)
 
-# target_include_directories(plugin_tool PUBLIC
-#   include
-#   ${ament_index_cpp_INCLUDE_DIRS}
-#   ${class_loader_INCLUDE_DIRS}
-#   ${tinyxml2_INCLUDE_DIRS}
-# )
-# target_link_libraries(plugin_tool
-#   ${ament_index_cpp_LIBRARIES}
-#   ${class_loader_LIBRARIES}
-#   ${tinyxml2_LIBRARIES}
-# )
-
 install(
   DIRECTORY cmake
   DESTINATION share/${PROJECT_NAME}


### PR DESCRIPTION
Looks like this got unwillingly readded in https://github.com/ros/pluginlib/commit/244f065db2f110b15ec19b6ec797d28ea455d973#diff-af3b638bc2a3e6c650974192a53c7291.
Note: it has been removed from melodic in #61 