### PR TITLE
vs2015 doesnt support __has_include, VS2015 and 2017 have both <files…

### DIFF
--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -35,7 +35,20 @@
 #ifndef PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 #define PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 
-#if defined(__has_include)
+#if defined(_MSC_VER)
+#include <experimental/filesystem> // C++-standard header file name  
+#include <filesystem> // Microsoft-specific implementation header file name  
+namespace pluginlib
+{
+namespace impl
+{
+namespace fs = std::experimental::filesystem;
+}  // namespace impl
+}  // namespace pluginlib
+
+#define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+
+#elif defined(__has_include)
 #if __has_include(<filesystem>)
 # include <filesystem>
 

--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -36,8 +36,7 @@
 #define PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 
 #if defined(_MSC_VER)
-#include <experimental/filesystem> // C++-standard header file name  
-#include <filesystem> // Microsoft-specific implementation header file name  
+# include <experimental/filesystem>
 namespace pluginlib
 {
 namespace impl

--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -35,7 +35,8 @@
 #ifndef PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 #define PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 
-#if defined(_MSC_VER)
+
+#if _MSC_VER >= 1900
 # include <experimental/filesystem>
 namespace pluginlib
 {
@@ -45,11 +46,11 @@ namespace fs = std::experimental::filesystem;
 }  // namespace impl
 }  // namespace pluginlib
 
-#define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+# define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
 
 #elif defined(__has_include)
-#if __has_include(<filesystem>)
-# include <filesystem>
+# if __has_include(<filesystem>)
+#  include <filesystem>
 
 namespace pluginlib
 {
@@ -59,9 +60,9 @@ namespace fs = std::filesystem;
 }  // namespace impl
 }  // namespace pluginlib
 
-#define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-#elif __has_include(<experimental/filesystem>)
-# include <experimental/filesystem>
+#  define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+# elif __has_include(<experimental/filesystem>)
+#  include <experimental/filesystem>
 
 namespace pluginlib
 {
@@ -71,8 +72,8 @@ namespace fs = std::experimental::filesystem;
 }  // namespace impl
 }  // namespace pluginlib
 
-#define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-#endif
+#  define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+# endif
 #endif
 
 // The standard library does not provide it, so emulate it.


### PR DESCRIPTION
…ystem> and <experimental/filesystem> but use std::experimental::filesystem in both cases

This is a redo of #92 kindly contributed by @bfjelds, I had to open another PR as the folder structure changed and resolving conflicts will be inconvenient.

The rationale for the change and the compiler versions it applies to are documented [here](https://github.com/ros/pluginlib/pull/92#pullrequestreview-85229871).

@wjwwood As the original author of the filesystem detection logic, would you mind giving this a :eyes: before I merge it ?