### PR TITLE
use new class_loader errors and fix deprecation warnings

### DIFF
--- a/pluginlib/include/pluginlib/class_list_macros.hpp
+++ b/pluginlib/include/pluginlib/class_list_macros.hpp
@@ -37,7 +37,7 @@
 #ifndef PLUGINLIB__CLASS_LIST_MACROS_HPP_
 #define PLUGINLIB__CLASS_LIST_MACROS_HPP_
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 /// Register a class with class loader to effectively export it for plugin loading later.
 /**

--- a/pluginlib/include/pluginlib/class_loader.hpp
+++ b/pluginlib/include/pluginlib/class_loader.hpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include "boost/algorithm/string.hpp"
-#include "class_loader/multi_library_class_loader.h"
+#include "class_loader/multi_library_class_loader.hpp"
 #include "pluginlib/class_desc.hpp"
 #include "pluginlib/class_loader_base.hpp"
 #include "pluginlib/exceptions.hpp"

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -51,7 +51,7 @@
 #include "boost/bind.hpp"
 #include "boost/filesystem.hpp"
 #include "boost/foreach.hpp"
-#include "class_loader/class_loader.h"
+#include "class_loader/class_loader.hpp"
 
 #include "ros/package.h"
 


### PR DESCRIPTION
redo of #99 applied to melodic-devel