### PR TITLE
ROS 2 : remove extra semicolon to fix pedantic warning

### DIFF
--- a/pluginlib/include/pluginlib/class_list_macros.hpp
+++ b/pluginlib/include/pluginlib/class_list_macros.hpp
@@ -46,6 +46,6 @@
  * \param base_class_type The real base class type from which class_type inherits
  */
 #define PLUGINLIB_EXPORT_CLASS(class_type, base_class_type) \
-  CLASS_LOADER_REGISTER_CLASS(class_type, base_class_type);
+  CLASS_LOADER_REGISTER_CLASS(class_type, base_class_type)
 
 #endif  // PLUGINLIB__CLASS_LIST_MACROS_HPP_


### PR DESCRIPTION
fixes #102 

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4058)](http://ci.ros2.org/job/ci_linux/4058/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1142)](http://ci.ros2.org/job/ci_linux-aarch64/1142/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3371)](http://ci.ros2.org/job/ci_osx/3371/) (unrelated test failure)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4136)](http://ci.ros2.org/job/ci_windows/4136/) (unrelated test failure)