### PR TITLE
update pluginlib and class_loader headers to use the new hpp ones

### DIFF
--- a/include/pluginlib/class_list_macros.hpp
+++ b/include/pluginlib/class_list_macros.hpp
@@ -37,7 +37,7 @@
 #ifndef PLUGINLIB__CLASS_LIST_MACROS_HPP_
 #define PLUGINLIB__CLASS_LIST_MACROS_HPP_
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 /**
  * \def PLUGINLIB_REGISTER_CLASS(class_name, class_type, base_class_type)

--- a/include/pluginlib/class_loader.hpp
+++ b/include/pluginlib/class_loader.hpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include "boost/algorithm/string.hpp"
-#include "class_loader/multi_library_class_loader.h"
+#include "class_loader/multi_library_class_loader.hpp"
 #include "pluginlib/class_desc.hpp"
 #include "pluginlib/class_loader_base.hpp"
 #include "pluginlib/exceptions.hpp"

--- a/include/pluginlib/class_loader_imp.hpp
+++ b/include/pluginlib/class_loader_imp.hpp
@@ -51,7 +51,7 @@
 #include "boost/bind.hpp"
 #include "boost/filesystem.hpp"
 #include "boost/foreach.hpp"
-#include "class_loader/class_loader.h"
+#include "class_loader/class_loader.hpp"
 
 #include "ros/package.h"
 

--- a/share/pluginlib/typed_class_loader_template.cpp
+++ b/share/pluginlib/typed_class_loader_template.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <ros/console.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <vector>
 #include <string>
 #include <iostream>

--- a/src/plugin_tool.cpp
+++ b/src/plugin_tool.cpp
@@ -28,7 +28,7 @@
  */
 
 #include <dlfcn.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <ros/console.h>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
Disclaimer: This in an automated PR, if it is not relevant on this branch, apologies for the inconveniance, feel free to close it.

----

Pluginlib and class_loader headers have been renamed. The previous headers `.h` have been deprecated in favor of their `.hpp` equivalent. The new headers are available on all active ROS disctributions and the deprecated ones will be removed in the next version of ROS.

This PR migrates the include statements to use the non-deprecated ones