### PR TITLE
remove deprecation warning until sers are required to change code

### DIFF
--- a/pluginlib/include/pluginlib/class_desc.h
+++ b/pluginlib/include/pluginlib/class_desc.h
@@ -32,10 +32,6 @@
 #ifndef PLUGINLIB__CLASS_DESC_H_
 #define PLUGINLIB__CLASS_DESC_H_
 
-// *INDENT-OFF* (prevent uncrustify from adding indention below)
-#warning Including header <pluginlib/class_desc.h> is deprecated, \
-include <pluginlib/class_desc.hpp> instead.
-
 #include "./class_desc.hpp"
 
 #endif  // PLUGINLIB__CLASS_DESC_H_

--- a/pluginlib/include/pluginlib/class_list_macros.h
+++ b/pluginlib/include/pluginlib/class_list_macros.h
@@ -32,10 +32,6 @@
 #ifndef PLUGINLIB__CLASS_LIST_MACROS_H_
 #define PLUGINLIB__CLASS_LIST_MACROS_H_
 
-// *INDENT-OFF* (prevent uncrustify from adding indention below)
-#warning Including header <pluginlib/class_list_macros.h> is deprecated, \
-include <pluginlib/class_list_macros.hpp> instead.
-
 #include "./class_list_macros.hpp"
 
 #endif  // PLUGINLIB__CLASS_LIST_MACROS_H_

--- a/pluginlib/include/pluginlib/class_loader.h
+++ b/pluginlib/include/pluginlib/class_loader.h
@@ -32,10 +32,6 @@
 #ifndef PLUGINLIB__CLASS_LOADER_H_
 #define PLUGINLIB__CLASS_LOADER_H_
 
-// *INDENT-OFF* (prevent uncrustify from adding indention below)
-#warning Including header <pluginlib/class_loader.h> is deprecated, \
-include <pluginlib/class_loader.hpp> instead.
-
 #include "./class_loader.hpp"
 
 #endif  // PLUGINLIB__CLASS_LOADER_H_

--- a/pluginlib/include/pluginlib/class_loader_base.h
+++ b/pluginlib/include/pluginlib/class_loader_base.h
@@ -32,10 +32,6 @@
 #ifndef PLUGINLIB__CLASS_LOADER_BASE_H_
 #define PLUGINLIB__CLASS_LOADER_BASE_H_
 
-// *INDENT-OFF* (prevent uncrustify from adding indention below)
-#warning Including header <pluginlib/class_loader_base.h> is deprecated, \
-include <pluginlib/class_loader_base.hpp> instead.
-
 #include "./class_loader_base.hpp"
 
 #endif  // PLUGINLIB__CLASS_LOADER_BASE_H_

--- a/pluginlib/include/pluginlib/pluginlib_exceptions.h
+++ b/pluginlib/include/pluginlib/pluginlib_exceptions.h
@@ -32,10 +32,6 @@
 #ifndef PLUGINLIB__PLUGINLIB_EXCEPTIONS_H_
 #define PLUGINLIB__PLUGINLIB_EXCEPTIONS_H_
 
-// *INDENT-OFF* (prevent uncrustify from adding indention below)
-#warning Including header <pluginlib/pluginlib_exceptions.h> is deprecated, \
-include <pluginlib/exceptions.hpp> instead.
-
 #include "./exceptions.hpp"
 
 #endif  // PLUGINLIB__PLUGINLIB_EXCEPTIONS_H_


### PR DESCRIPTION
based on discussion from https://github.com/ros/pluginlib/pull/70#issuecomment-379435585. We will remove deprecation warnings until we roll out more refactor to pluginlib at wich point we will deprecate them gain and remove them in the following distribution.