### PR TITLE
Fix compile error with gcc 8.1.0

### DIFF
--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -49,7 +49,7 @@ namespace fs = std::experimental::filesystem;
 # define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
 
 #elif defined(__has_include)
-# if __has_include(<filesystem>)
+# if __has_include(<filesystem>) && __cplusplus >= 201703L
 #  include <filesystem>
 
 namespace pluginlib

--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -36,8 +36,9 @@
 #define PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 
 
-#if _MSC_VER >= 1900
-# include <experimental/filesystem>
+#if defined(_MSC_VER)
+# if _MSC_VER >= 1900
+#  include <experimental/filesystem>
 namespace pluginlib
 {
 namespace impl
@@ -46,7 +47,8 @@ namespace fs = std::experimental::filesystem;
 }  // namespace impl
 }  // namespace pluginlib
 
-# define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+#  define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+# endif
 
 #elif defined(__has_include)
 # if __has_include(<filesystem>) && __cplusplus >= 201703L


### PR DESCRIPTION
Gcc 8.1.0 fails to compile filesystem_helper.hpp with -std=c++14. The cause is that it passes the check "__has_include(<filesystem>)". However, std::filesystem is not defined. We add an additional check "__cplusplus >= 201703L".