### PR TITLE
export rcutils

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -13,10 +13,11 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(class_loader REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
-ament_export_dependencies(ament_index_cpp class_loader tinyxml2_vendor TinyXML2)
+ament_export_dependencies(ament_index_cpp class_loader rcutils tinyxml2_vendor TinyXML2)
 ament_export_include_directories(include)
 
 install(

--- a/pluginlib/package.xml
+++ b/pluginlib/package.xml
@@ -22,6 +22,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>class_loader</depend>
+  <depend>rcutils</depend>
   <depend>tinyxml2_vendor</depend>
 
   <export>


### PR DESCRIPTION
ran into issues when building in overlay:

```
In file included from /Users/karsten/workspace/osrf/ros2_full/install/pluginlib/include/pluginlib/class_loader.hpp:357:
/Users/karsten/workspace/osrf/ros2_full/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:55:10: fatal error: 'rcutils/logging_macros.h' file not found
#include "rcutils/logging_macros.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
When applying this patch (exporting `rcutils` as a dependency), this problem is resolved.