### PR TITLE
[ros2] respect plugin description file subdirectory

### DIFF
--- a/pluginlib/cmake/pluginlib_export_plugin_description_file.cmake
+++ b/pluginlib/cmake/pluginlib_export_plugin_description_file.cmake
@@ -84,7 +84,9 @@ macro(pluginlib_export_plugin_description_file plugin_category relative_filename
     message(FATAL_ERROR "Given plugin description file '${abs_filename}' does not exist")
   endif()
 
-  install(FILES ${relative_filename} DESTINATION share/${PROJECT_NAME})
+  set(relative_dir "")
+  get_filename_component(relative_dir "${relative_filename}" DIRECTORY)
+  install(FILES ${relative_filename} DESTINATION share/${relative_dir}/${PROJECT_NAME})
 
   # this accumulated value is written to the ament index resource file in the
   # ament_package() call via the pluginlib hook

--- a/pluginlib/cmake/pluginlib_export_plugin_description_file.cmake
+++ b/pluginlib/cmake/pluginlib_export_plugin_description_file.cmake
@@ -86,7 +86,7 @@ macro(pluginlib_export_plugin_description_file plugin_category relative_filename
 
   set(relative_dir "")
   get_filename_component(relative_dir "${relative_filename}" DIRECTORY)
-  install(FILES ${relative_filename} DESTINATION share/${relative_dir}/${PROJECT_NAME})
+  install(FILES ${relative_filename} DESTINATION share/${PROJECT_NAME}/${relative_dir})
 
   # this accumulated value is written to the ament index resource file in the
   # ament_package() call via the pluginlib hook


### PR DESCRIPTION
This modifies the macro to install the plugin description file to match the macro docblock: https://github.com/ros/pluginlib/blob/dfa003621c0d0fc1f19adaa76030f8a427678b19/pluginlib/cmake/pluginlib_export_plugin_description_file.cmake#L36-L40

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4931)](http://ci.ros2.org/job/ci_linux/4931/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1754)](http://ci.ros2.org/job/ci_linux-aarch64/1754/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4093)](http://ci.ros2.org/job/ci_osx/4093/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4950)](http://ci.ros2.org/job/ci_windows/4950/)

@Karsten1987 @wjwwood FYI