### PR TITLE
adding ament_package() to test_pluginlib

### DIFF
--- a/test_pluginlib/CMakeLists.txt
+++ b/test_pluginlib/CMakeLists.txt
@@ -37,3 +37,5 @@ if(BUILD_TESTING)
     target_compile_definitions(${PROJECT_NAME}_utest PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
   endif()
 endif()
+
+ament_package()


### PR DESCRIPTION
Without this change sourcing your environment gives you the following output:

```
not found: "/home/mike/ws_ros2/install/test_pluginlib/share/test_pluginlib/local_setup.sh"
not found: "/home/mike/ws_ros2/install/test_pluginlib/share/test_pluginlib/local_setup.bash"
```