### PR TITLE
strip 'lib' prefix when loading library on Windows

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -16,6 +16,11 @@ if(CATKIN_ENABLE_TESTING)
 
   add_library(test_plugins EXCLUDE_FROM_ALL SHARED test/test_plugins.cpp)
   target_link_libraries(test_plugins ${class_loader_LIBRARIES})
+  if(WIN32)
+    # On Windows, default library runtime output set to CATKIN_GLOBAL_BIN_DESTINATION,
+    # change it back to CATKIN_PACKAGE_LIB_DESTINATION to match the library path described in plugin description file
+    set_target_properties(test_plugins PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION})
+  endif()
 
   catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}_utest)

--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -16,11 +16,6 @@ if(CATKIN_ENABLE_TESTING)
 
   add_library(test_plugins EXCLUDE_FROM_ALL SHARED test/test_plugins.cpp)
   target_link_libraries(test_plugins ${class_loader_LIBRARIES})
-  if(WIN32)
-    # On Windows, default library runtime output set to CATKIN_GLOBAL_BIN_DESTINATION,
-    # change it back to CATKIN_PACKAGE_LIB_DESTINATION to match the library path described in plugin description file
-    set_target_properties(test_plugins PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION})
-  endif()
 
   catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}_utest)

--- a/pluginlib/include/pluginlib/class_loader.hpp
+++ b/pluginlib/include/pluginlib/class_loader.hpp
@@ -288,11 +288,9 @@ private:
     const std::string & library_name,
     const std::string & exporting_package_name);
 
-#ifdef _WIN32
   std::string getClassLibraryPathFromLibraryName(
     const std::string & library_name,
     const std::string & package_name);
-#endif
 
   /// Return the paths where libraries are installed according to the Catkin build system.
   std::vector<std::string> getCatkinLibraryPaths();

--- a/pluginlib/include/pluginlib/class_loader.hpp
+++ b/pluginlib/include/pluginlib/class_loader.hpp
@@ -288,6 +288,12 @@ private:
     const std::string & library_name,
     const std::string & exporting_package_name);
 
+#ifdef _WIN32
+  std::string getClassLibraryPathFromLibraryName(
+    const std::string & library_name,
+    const std::string & package_name);
+#endif
+
   /// Return the paths where libraries are installed according to the Catkin build system.
   std::vector<std::string> getCatkinLibraryPaths();
 

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -417,7 +417,7 @@ std::string ClassLoader<T>::getClassLibraryPath(const std::string & lookup_name)
 
 #ifdef _WIN32
   // Windows does not add 'lib' prefix to libary name, remove the prefix and try again
-  if ("" == library_path) {
+  if (library_path.empty()) {
     std::string only_path;
     std::string only_file;
     size_t c = library_name.find_last_of(getPathSeparator());


### PR DESCRIPTION
Windows does not add `lib` prefix to libary name, if 
```
std::string library_path = getClassLibraryPathFromLibraryName(library_name, it->second.package_);
```
fails to find the library path, remove the prefix and try again

this code change does not alter existing logic on Linux