### PR TITLE
 set Dll destination to CATKIN_PACKAGE_LIB_DESTINATION

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -16,6 +16,11 @@ if(CATKIN_ENABLE_TESTING)
 
   add_library(test_plugins EXCLUDE_FROM_ALL SHARED test/test_plugins.cpp)
   target_link_libraries(test_plugins ${class_loader_LIBRARIES})
+  if(WIN32)
+    # On Windows, default library runtime output set to CATKIN_GLOBAL_BIN_DESTINATION,
+    # change it back to CATKIN_PACKAGE_LIB_DESTINATION to match the library path described in plugin description file
+    set_target_properties(test_plugins PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION})
+  endif()
 
   catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}_utest)


### PR DESCRIPTION
currently [catkin logic on Windows](https://github.com/ros/catkin/blob/kinetic-devel/cmake/platform/windows.cmake) would publish dll's to global binary destination for devel space:
```
RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION}
```

however, this is mainly needed for ROS core packages for backward compatibility support. For the vast majority of packages, publishing to the package's bin directory would be okay.

for `test_plugin`, given it's a plugin, its look-up path is hard-coded in [test_plugins.xml](https://github.com/ros/pluginlib/blob/melodic-devel/pluginlib/test/test_plugins.xml#L1) as `lib\...`, so it has to be exported to `CATKIN_PACKAGE_LIB_DESTINATION`