### PR TITLE
also search under bin if on Windows

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -310,12 +310,11 @@ std::vector<std::string> ClassLoader<T>::getCatkinLibraryPaths()
     boost::split(catkin_prefix_paths, env_catkin_prefix_paths, boost::is_any_of(os_pathsep));
     BOOST_FOREACH(std::string catkin_prefix_path, catkin_prefix_paths) {
       boost::filesystem::path path(catkin_prefix_path);
-#if WIN32
-	  boost::filesystem::path bin("bin");
-	  lib_paths.push_back((path / bin).string());
+#if _WIN32
+      boost::filesystem::path bin("bin");
+      lib_paths.push_back((path / bin).string());
 #endif
-
-	  boost::filesystem::path lib("lib");
+      boost::filesystem::path lib("lib");
       lib_paths.push_back((path / lib).string());
     }
   }

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -310,7 +310,12 @@ std::vector<std::string> ClassLoader<T>::getCatkinLibraryPaths()
     boost::split(catkin_prefix_paths, env_catkin_prefix_paths, boost::is_any_of(os_pathsep));
     BOOST_FOREACH(std::string catkin_prefix_path, catkin_prefix_paths) {
       boost::filesystem::path path(catkin_prefix_path);
-      boost::filesystem::path lib("lib");
+#if WIN32
+	  boost::filesystem::path bin("bin");
+	  lib_paths.push_back((path / bin).string());
+#endif
+
+	  boost::filesystem::path lib("lib");
       lib_paths.push_back((path / lib).string());
     }
   }


### PR DESCRIPTION
search under bin if on Windows

similar logics has already been added/implemented in the [`ros2` branch](https://github.com/ros/pluginlib/blob/ros2/pluginlib/include/pluginlib/class_loader_imp.hpp#L416), this could be considered as a back-port as well as a fix for Windows