### PR TITLE
Dynamically choose the appropriate library for experimental filesystem

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -33,6 +33,16 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+      set(FILESYSTEM_LIB c++experimental)
+    else()
+      set(FILESYSTEM_LIB c++fs)
+    endif()
+  else()
+    set(FILESYSTEM_LIB stdc++fs)
+  endif()
+
   set(prefix "${CMAKE_CURRENT_BINARY_DIR}/prefix")
 
   # Write the necessary files for ament to detect a package.
@@ -81,7 +91,7 @@ if(BUILD_TESTING)
     target_compile_definitions(${PROJECT_NAME}_unique_ptr_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
     if(UNIX AND NOT APPLE)
-      target_link_libraries(${PROJECT_NAME}_unique_ptr_test stdc++fs)
+      target_link_libraries(${PROJECT_NAME}_unique_ptr_test ${FILESYSTEM_LIB})
     endif()
     add_dependencies(${PROJECT_NAME}_unique_ptr_test test_plugins)
   endif()
@@ -102,7 +112,7 @@ if(BUILD_TESTING)
     target_compile_definitions(${PROJECT_NAME}_utest PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
     if(UNIX AND NOT APPLE)
-      target_link_libraries(${PROJECT_NAME}_utest stdc++fs)
+      target_link_libraries(${PROJECT_NAME}_utest ${FILESYSTEM_LIB})
     endif()
     add_dependencies(${PROJECT_NAME}_utest test_plugins)
   endif()

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -20,8 +20,18 @@ ament_register_extension("ament_package" "pluginlib"
 
 include("${pluginlib_DIR}/pluginlib_export_plugin_description_file.cmake")
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+    set(FILESYSTEM_LIB c++experimental)
+  else()
+    set(FILESYSTEM_LIB c++fs)
+  endif()
+else()
+  set(FILESYSTEM_LIB stdc++fs)
+endif()
+
 if(UNIX AND NOT APPLE)
   # this is needed to use the experimental/filesystem on Linux, but cannot be passed with
   # ament_export_libraries() because it is not absolute and cannot be found with find_library
-  list(APPEND pluginlib_LIBRARIES stdc++fs)
+  list(APPEND pluginlib_LIBRARIES ${FILESYSTEM_LIB})
 endif()


### PR DESCRIPTION
Choose based on the compiler and standard library

Signed-off-by: Emerson Knapp <eknapp@amazon.com>

Related to ros2/ros2#664