### PR TITLE
class_loader_imp: do not call virtual function in destructor

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -100,7 +100,7 @@ ClassLoader<T>::~ClassLoader()
 /***************************************************************************/
 {
   ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Destroying ClassLoader, base = %s, address = %p",
-    getBaseClassType().c_str(), this);
+    ClassLoader<T>::getBaseClassType().c_str(), this);
 }
 
 


### PR DESCRIPTION
This fixes clang-tidys "clang-analyzer-optin.cplusplus.VirtualCall"-warning.

Also this makes more clear, which function is actually called.