### PR TITLE
[ros2] Cast pointers to void * when using %p

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -101,7 +101,7 @@ ClassLoader<T>::ClassLoader(
   /***************************************************************************/
 {
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",
-    base_class.c_str(), this);
+    base_class.c_str(), static_cast<void *>(this));
   try {
     ament_index_cpp::get_package_prefix(package_);
   } catch (const ament_index_cpp::PackageNotFoundError & exception) {
@@ -115,7 +115,7 @@ ClassLoader<T>::ClassLoader(
   classes_available_ = determineAvailableClasses(plugin_xml_paths_);
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
     "Finished constructring ClassLoader, base = %s, address = %p",
-    base_class.c_str(), this);
+    base_class.c_str(), static_cast<void *>(this));
 }
 
 template<class T>
@@ -124,7 +124,7 @@ ClassLoader<T>::~ClassLoader()
 {
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
     "Destroying ClassLoader, base = %s, address = %p",
-    getBaseClassType().c_str(), this);
+    getBaseClassType().c_str(), static_cast<void *>(this));
 }
 
 
@@ -148,7 +148,7 @@ T * ClassLoader<T>::createClassInstance(const std::string & lookup_name, bool au
       "Attempting to create instance through low-level MultiLibraryClassLoader...");
     T * obj = lowlevel_class_loader_.createUnmanagedInstance<T>(getClassType(lookup_name));
     RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "Instance created with object pointer = %p", obj);
+      "Instance created with object pointer = %p", static_cast<void *>(obj));
 
     return obj;
   } catch (const class_loader::CreateClassException & ex) {


### PR DESCRIPTION
I'm seeing a new build failure in `rviz_common` due to it using `-Werror=format`. The compiler is complaining about using `%p` with a pointer type that is not a `void *`. I don't know what change is responsible. This PR fixes it by adding a cast.

<details> <summary>Build output without this PR </summary>

```
--- stderr: rviz_common                                         
In file included from /home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:71:0,
                 from /home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/class_loader.hpp:370,
                 from /home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp:42,
                 from /home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/./display_factory.hpp:38,
                 from /home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/display_factory.cpp:31:
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp: In instantiation of ‘pluginlib::ClassLoader<T>::ClassLoader(std::__cxx11::string, std::__cxx11::string, std::__cxx11::string, std::vector<std::__cxx11::basic_string<char> >) [with T = rviz_common::Display; std::__cxx11::string = std::__cxx11::basic_string<char>]’:
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp:69:21:   required from ‘rviz_common::PluginlibFactory<Type>::PluginlibFactory(const QString&, const QString&) [with Type = rviz_common::Display]’
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/display_factory.cpp:50:66:   required from here
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:72:18: error: format ‘%p’ expects argument of type ‘void*’, but argument 6 has type ‘pluginlib::ClassLoader<rviz_common::Display>*’ [-Werror=format=]
       rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:253:3: note: in expansion of macro ‘RCUTILS_LOG_COND_NAMED’
   RCUTILS_LOG_COND_NAMED( \
   ^~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:103:3: note: in expansion of macro ‘RCUTILS_LOG_DEBUG_NAMED’
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:72:18: error: format ‘%p’ expects argument of type ‘void*’, but argument 6 has type ‘pluginlib::ClassLoader<rviz_common::Display>*’ [-Werror=format=]
       rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:253:3: note: in expansion of macro ‘RCUTILS_LOG_COND_NAMED’
   RCUTILS_LOG_COND_NAMED( \
   ^~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:116:3: note: in expansion of macro ‘RCUTILS_LOG_DEBUG_NAMED’
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp: In instantiation of ‘pluginlib::ClassLoader<T>::~ClassLoader() [with T = rviz_common::Display]’:
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp:75:5:   required from ‘rviz_common::PluginlibFactory<Type>::~PluginlibFactory() [with Type = rviz_common::Display]’
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/display_factory.cpp:50:66:   required from here
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:72:18: error: format ‘%p’ expects argument of type ‘void*’, but argument 6 has type ‘pluginlib::ClassLoader<rviz_common::Display>*’ [-Werror=format=]
       rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:253:3: note: in expansion of macro ‘RCUTILS_LOG_COND_NAMED’
   RCUTILS_LOG_COND_NAMED( \
   ^~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:125:3: note: in expansion of macro ‘RCUTILS_LOG_DEBUG_NAMED’
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
   ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:71:0,
                 from /home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/class_loader.hpp:370,
                 from /home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp:42,
                 from /home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/./panel_factory.hpp:35,
                 from /home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/panel_factory.cpp:32:
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp: In instantiation of ‘pluginlib::ClassLoader<T>::ClassLoader(std::__cxx11::string, std::__cxx11::string, std::__cxx11::string, std::vector<std::__cxx11::basic_string<char> >) [with T = rviz_common::Panel; std::__cxx11::string = std::__cxx11::basic_string<char>]’:
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp:69:21:   required from ‘rviz_common::PluginlibFactory<Type>::PluginlibFactory(const QString&, const QString&) [with Type = rviz_common::Panel]’
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/panel_factory.cpp:60:62:   required from here
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:72:18: error: format ‘%p’ expects argument of type ‘void*’, but argument 6 has type ‘pluginlib::ClassLoader<rviz_common::Panel>*’ [-Werror=format=]
       rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:253:3: note: in expansion of macro ‘RCUTILS_LOG_COND_NAMED’
   RCUTILS_LOG_COND_NAMED( \
   ^~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:103:3: note: in expansion of macro ‘RCUTILS_LOG_DEBUG_NAMED’
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:72:18: error: format ‘%p’ expects argument of type ‘void*’, but argument 6 has type ‘pluginlib::ClassLoader<rviz_common::Panel>*’ [-Werror=format=]
       rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:253:3: note: in expansion of macro ‘RCUTILS_LOG_COND_NAMED’
   RCUTILS_LOG_COND_NAMED( \
   ^~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:116:3: note: in expansion of macro ‘RCUTILS_LOG_DEBUG_NAMED’
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp: In instantiation of ‘pluginlib::ClassLoader<T>::~ClassLoader() [with T = rviz_common::Panel]’:
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp:75:5:   required from ‘rviz_common::PluginlibFactory<Type>::~PluginlibFactory() [with Type = rviz_common::Panel]’
/home/sloretz/ws/ros2/src/ros2/rviz/rviz_common/src/rviz_common/panel_factory.cpp:60:62:   required from here
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:72:18: error: format ‘%p’ expects argument of type ‘void*’, but argument 6 has type ‘pluginlib::ClassLoader<rviz_common::Panel>*’ [-Werror=format=]
       rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/rcutils/include/rcutils/logging_macros.h:253:3: note: in expansion of macro ‘RCUTILS_LOG_COND_NAMED’
   RCUTILS_LOG_COND_NAMED( \
   ^~~~~~~~~~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/pluginlib/include/pluginlib/./class_loader_imp.hpp:125:3: note: in expansion of macro ‘RCUTILS_LOG_DEBUG_NAMED’
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
   ^~~~~~~~~~~~~~~~~~~~~~~
cc1plus: error: unrecognized command line option ‘-Wno-gnu-zero-variadic-macro-arguments’ [-Werror]
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/rviz_common.dir/src/rviz_common/display_factory.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
cc1plus: error: unrecognized command line option ‘-Wno-gnu-zero-variadic-macro-arguments’ [-Werror]
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/rviz_common.dir/src/rviz_common/panel_factory.cpp.o] Error 1
make[1]: *** [CMakeFiles/rviz_common.dir/all] Error 2
make: *** [all] Error 2

```

</details>