### PR TITLE
Fix format string warnings.

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -101,7 +101,7 @@ ClassLoader<T>::ClassLoader(
   /***************************************************************************/
 {
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",
-    base_class.c_str(), this);
+    base_class.c_str(), (void *)this);
   try {
     ament_index_cpp::get_package_prefix(package_);
   } catch (const ament_index_cpp::PackageNotFoundError & exception) {
@@ -115,7 +115,7 @@ ClassLoader<T>::ClassLoader(
   classes_available_ = determineAvailableClasses(plugin_xml_paths_);
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
     "Finished constructring ClassLoader, base = %s, address = %p",
-    base_class.c_str(), this);
+    base_class.c_str(), (void *)this);
 }
 
 template<class T>
@@ -124,7 +124,7 @@ ClassLoader<T>::~ClassLoader()
 {
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
     "Destroying ClassLoader, base = %s, address = %p",
-    getBaseClassType().c_str(), this);
+    getBaseClassType().c_str(), (void *)this);
 }
 
 
@@ -148,7 +148,7 @@ T * ClassLoader<T>::createClassInstance(const std::string & lookup_name, bool au
       "Attempting to create instance through low-level MultiLibraryClassLoader...");
     T * obj = lowlevel_class_loader_.createUnmanagedInstance<T>(getClassType(lookup_name));
     RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "Instance created with object pointer = %p", obj);
+      "Instance created with object pointer = %p", (void *)obj);
 
     return obj;
   } catch (const class_loader::CreateClassException & ex) {


### PR DESCRIPTION
With https://github.com/ros2/rcutils/pull/154 warnings are emitted for "dangerous patterns" in format strings.
%p expects a `void *` argument so a `void *` argument we shall provide.