### PR TITLE
Export tinyxml2 libraries downstream

### DIFF
--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -35,3 +35,7 @@ if(UNIX AND NOT APPLE)
   # ament_export_libraries() because it is not absolute and cannot be found with find_library
   list(APPEND pluginlib_LIBRARIES ${FILESYSTEM_LIB})
 endif()
+
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)
+list(APPEND pluginlib_LIBRARIES ${TinyXML2_LIBRARIES})


### PR DESCRIPTION
This change makes the tinxyml2 libraries available to downstream packages when they are crosscompiled. The calls to `find_package` are in the extras file because the tinyxml2 libraries may be installed system-wide and therefore have absolute paths, which can't be resolved when crosscompiling.