### PR TITLE
Check for NULL in XMLElement::Attribute

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -665,7 +665,13 @@ void ClassLoader<T>::processSingleXMLPluginFile(
 
   tinyxml2::XMLElement * library = config;
   while (library != NULL) {
-    std::string library_path = library->Attribute("path");
+    const char* path = library->Attribute("path");
+    if (NULL == path) {
+      ROS_ERROR_NAMED("pluginlib.ClassLoader",
+        "Attribute 'path' in 'library' tag is missing in %s.", xml_file.c_str());
+      continue;
+    }
+    std::string library_path(path);
     if (0 == library_path.size()) {
       ROS_ERROR_NAMED("pluginlib.ClassLoader",
         "Attribute 'path' in 'library' tag is missing in %s.", xml_file.c_str());


### PR DESCRIPTION
Check for `NULL`   pointer returned by `tinyxml2::XMLElement::Attribute`. 
```std::string my_string(NULL)``` is UB.

Fix #160

Signed-off-by: artivis <jeremie.deray@canonical.com>