### PR TITLE
Use __cpp_lib_... macros instead of __has_include

### DIFF
--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -35,10 +35,8 @@
 #ifndef PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 #define PLUGINLIB__IMPL__FILESYSTEM_HELPER_HPP_
 
-
-#if defined(__has_include)
-# if __has_include(<filesystem>) && __cplusplus >= 201703L
-#  include <filesystem>
+#if defined(__cpp_lib_filesystem)
+# include <filesystem>
 
 namespace pluginlib
 {
@@ -48,12 +46,9 @@ namespace fs = std::filesystem;
 }  // namespace impl
 }  // namespace pluginlib
 
-#  define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-# elif __has_include(<experimental/filesystem>)
-// MSVC deprecates <experimental/filesystem> and in favor of <filesystem>
-// use this macro to acknowledge this deprecation and unblock the build break
-#  define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
-#  include <experimental/filesystem>
+# define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+#elif defined(__cpp_lib_experimental_filesystem)
+# include <experimental/filesystem>
 
 namespace pluginlib
 {
@@ -63,8 +58,7 @@ namespace fs = std::experimental::filesystem;
 }  // namespace impl
 }  // namespace pluginlib
 
-#  define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-# endif
+# define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
 #endif
 
 // The standard library does not provide it, so emulate it.


### PR DESCRIPTION
The current check is fragile. Plus __has_include is not part of the C++14 standard.
See https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations

```
Starting >>> rosbag2_storage  
[Processing: rosbag2_storage]                                     
--- stderr: rosbag2_storage                                       
In file included from /opt/ros/master/src/ros2/rosbag2/rosbag2_storage/src/rosbag2_storage/storage_factory.cpp:24:
In file included from /opt/ros/master/src/ros2/rosbag2/rosbag2_storage/src/rosbag2_storage/./impl/storage_factory_impl.hpp:24:
In file included from /opt/ros/master/install/include/pluginlib/./class_loader.hpp:370:
In file included from /opt/ros/master/install/include/pluginlib/./class_loader_imp.hpp:74:
/opt/ros/master/install/include/pluginlib/./impl/filesystem_helper.hpp:62:35: error: 'filesystem' is deprecated: std::experimental::filesystem has now been deprecated in favor of C++17's std::filesystem. Please stop using it and start using std::filesystem. This experimental version will be removed in LLVM 11. You can remove this warning by defining the _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM macro. [-Werror,-Wdeprecated-declarations]
namespace fs = std::experimental::filesystem;
                                  ^
/usr/local/opt/llvm/bin/../include/c++/v1/experimental/filesystem:246:1: note: 'filesystem' has been explicitly marked deprecated here
_LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL_FILESYSTEM
^
/usr/local/opt/llvm/bin/../include/c++/v1/experimental/__config:46:63: note: expanded from macro '_LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL_FILESYSTEM'
    _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL namespace filesystem _LIBCPP_DEPRECATED_EXPERIMENTAL_FILESYSTEM { \
                                                              ^
/usr/local/opt/llvm/bin/../include/c++/v1/experimental/__config:42:70: note: expanded from macro '_LIBCPP_DEPRECATED_EXPERIMENTAL_FILESYSTEM'
#   define _LIBCPP_DEPRECATED_EXPERIMENTAL_FILESYSTEM __attribute__((deprecated("std::experimental::filesystem has now been deprecated in favor of C++17's std::filesystem. Please stop using it and start using std::filesystem. This experimental version will be removed in LLVM 11. You can remove this warning by defining the _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM macro.")))
                                                                     ^
1 error generated.
gmake[2]: *** [CMakeFiles/rosbag2_storage.dir/build.make:89: CMakeFiles/rosbag2_storage.dir/src/rosbag2_storage/storage_factory.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:117: CMakeFiles/rosbag2_storage.dir/all] Error 2
gmake: *** [Makefile:141: all] Error 2
---
Failed   <<< rosbag2_storage	[ Exited with code 2 ]
```