### PR TITLE
Update CMake minimum version to address CMP0048 warning.

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pluginlib)
 
 find_package(catkin REQUIRED COMPONENTS class_loader rosconsole roslib cmake_modules)


### PR DESCRIPTION
Hat tip to Shane whose comment in another PR diagnosed the warning:
https://github.com/ros/pluginlib/pull/171#issuecomment-586474749

Melodic's currently supported platforms, Stretch and Bionic, use CMake
3.7.2 and 3.10.2 respectively so this change can target melodic-devel.