### PR TITLE
[Windows] strip 'lib' prefix when loading library.

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -357,12 +357,30 @@ std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
   std::string stripped_library_name = stripAllButFileFromPath(library_name);
   std::string stripped_library_name_with_extension = stripped_library_name + non_debug_suffix;
 
+#ifdef _WIN32
+  // try to strip the leading `lib` from the library path.
+  // Windows doesn't have the `lib` prefix convention for shared libraries.
+  const std::string lib_suffix = "lib";
+  std::string stripped_library_name_win32 = stripped_library_name;
+  std::string stripped_library_name_with_extension_win32 = stripped_library_name + non_debug_suffix;
+  if (boost::starts_with(stripped_library_name, lib_suffix))
+  {
+    stripped_library_name_win32 = stripped_library_name_win32.substr(lib_suffix.length());
+    stripped_library_name_with_extension_win32 = stripped_library_name_with_extension_win32.substr(lib_suffix.length());
+  }
+  ROS_INFO_STREAM("stripped_library_name_win32: " << stripped_library_name_win32);
+  ROS_INFO_STREAM("stripped_library_name_with_extension_win32: " << stripped_library_name_with_extension_win32);
+#endif
+
   const std::string path_separator = getPathSeparator();
 
   for (unsigned int c = 0; c < all_paths_without_extension.size(); c++) {
     std::string current_path = all_paths_without_extension.at(c);
     all_paths.push_back(current_path + path_separator + library_name_with_extension);
     all_paths.push_back(current_path + path_separator + stripped_library_name_with_extension);
+#ifdef _WIN32
+    all_paths.push_back(current_path + path_separator + stripped_library_name_with_extension_win32);
+#endif
     // We're in debug mode, try debug libraries as well
     if (debug_library_suffix) {
       all_paths.push_back(
@@ -370,6 +388,11 @@ std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
       all_paths.push_back(
         current_path + path_separator + stripped_library_name +
         class_loader::systemLibrarySuffix());
+#ifdef _WIN32
+      all_paths.push_back(
+        current_path + path_separator + stripped_library_name_win32 +
+        class_loader::systemLibrarySuffix());
+#endif
     }
   }
 
@@ -805,7 +828,7 @@ std::string ClassLoader<T>::stripAllButFileFromPath(const std::string & path)
   if (std::string::npos == c) {
     return path;
   } else {
-    return path.substr(c, path.size());
+    return path.substr(c + 1);
   }
 }
 

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -368,8 +368,6 @@ std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
     stripped_library_name_win32 = stripped_library_name_win32.substr(lib_suffix.length());
     stripped_library_name_with_extension_win32 = stripped_library_name_with_extension_win32.substr(lib_suffix.length());
   }
-  ROS_INFO_STREAM("stripped_library_name_win32: " << stripped_library_name_win32);
-  ROS_INFO_STREAM("stripped_library_name_with_extension_win32: " << stripped_library_name_with_extension_win32);
 #endif
 
   const std::string path_separator = getPathSeparator();


### PR DESCRIPTION
This is a follow up of #140.

Many ROS packages are originally targeted for Linux and there is a convention to put the library prefix `lib` when describing `<library path="lib/libplugin">`. However, on Windows, the shared library doesn't have such naming convention. As a result, `class loader` is not able to find the library by names.

This pull request is to propose that `class loader` should also search the library name without `lib` prefix on Windows, which is as a mitigation to help downstream packages don't need to modify their plugin XML but still can load the plugin binaries.

This pull request is also fix an little problem that `stripAllButFileFromPath()` is returning the path separator in the result string. Based on the context of `getAllLibraryPathsToTry()`, the path separator seems to be an extra.