### PR TITLE
Fix warnings reported by Wformat

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -81,7 +81,7 @@ ClassLoader<T>::ClassLoader(
   /***************************************************************************/
 {
   ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",
-    base_class.c_str(), this);
+    base_class.c_str(), static_cast<void *>(this));
   if (ros::package::getPath(package_).empty()) {
     throw pluginlib::ClassLoaderException("Unable to find package: " + package_);
   }
@@ -92,7 +92,7 @@ ClassLoader<T>::ClassLoader(
   classes_available_ = determineAvailableClasses(plugin_xml_paths_);
   ROS_DEBUG_NAMED("pluginlib.ClassLoader",
     "Finished constructring ClassLoader, base = %s, address = %p",
-    base_class.c_str(), this);
+    base_class.c_str(), static_cast<void *>(this));
 }
 
 template<class T>
@@ -100,7 +100,7 @@ ClassLoader<T>::~ClassLoader()
 /***************************************************************************/
 {
   ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Destroying ClassLoader, base = %s, address = %p",
-    getBaseClassType().c_str(), this);
+    getBaseClassType().c_str(), static_cast<void *>(this));
 }
 
 
@@ -123,7 +123,7 @@ T * ClassLoader<T>::createClassInstance(const std::string & lookup_name, bool au
     ROS_DEBUG_NAMED("pluginlib.ClassLoader",
       "Attempting to create instance through low-level MultiLibraryClassLoader...");
     T * obj = lowlevel_class_loader_.createUnmanagedInstance<T>(getClassType(lookup_name));
-    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Instance created with object pointer = %p", obj);
+    ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Instance created with object pointer = %p", static_cast<void *>(obj));
 
     return obj;
   } catch (const class_loader::CreateClassException & ex) {


### PR DESCRIPTION
If I compile with `-Wall`, `-Wextra` and `-Wpedantic` I get the following error reported by `-Wformat`. This MR adds static casts to `void* ` which is the type that `%p` expects.

```
/opt/ros/melodic/include/pluginlib/././class_loader_imp.hpp: In instantiation of ‘pluginlib::ClassLoader<T>::ClassLoader(std::__cxx11::string, std::__cxx11::string, std::__cxx11::string, std::vector<std::__cxx11::basic_string<char> >) [with T = ?; std::__cxx11::string = std::__cxx11::basic_string<char>]’:
?:16:67:   required from here
/opt/ros/melodic/include/ros/console.h:348:26: warning: format ‘%p’ expects argument of type ‘void*’, but argument 9 has type ‘pluginlib::ClassLoader<?>*’ [-Wformat=]
     ::ros::console::print(filter, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, __FILE__, __LINE__, __ROSCONSOLE_FUNCTION__, __VA_ARGS__)
     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/melodic/include/ros/console.h:351:5: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER’
     ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER(NULL, __VA_ARGS__)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/melodic/include/ros/console.h:387:7: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION’
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/melodic/include/ros/console.h:572:35: note: in expansion of macro ‘ROS_LOG_COND’
 #define ROS_LOG(level, name, ...) ROS_LOG_COND(true, level, name, __VA_ARGS__)
                                   ^~~~~~~~~~~~
/opt/ros/melodic/include/rosconsole/macros_generated.h:60:36: note: in expansion of macro ‘ROS_LOG’
 #define ROS_DEBUG_NAMED(name, ...) ROS_LOG(::ros::console::levels::Debug, std::string(ROSCONSOLE_NAME_PREFIX) + "." + name, __VA_ARGS__)
                                    ^~~~~~~
/opt/ros/melodic/include/pluginlib/././class_loader_imp.hpp:83:3: note: in expansion of macro ‘ROS_DEBUG_NAMED’
   ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",
   ^
```

(I replaced my custom files and types with '?')
