### PR TITLE
Fix filesystem linking on clang9

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -33,6 +33,8 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
+  # NOTE this block is also defined in pluginlib-extras.cmake
+  # changes here need to be duplicated there
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
       # Before LLVM 7.0, filesystem is part of experimental

--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -35,9 +35,14 @@ if(BUILD_TESTING)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+      # Filesystem introduced to experimental in LLVM 7.0
       set(FILESYSTEM_LIB c++experimental)
-    else()
+    elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+      # Before LLVM 9.0 you have to manually link the fs library
       set(FILESYSTEM_LIB c++fs)
+    else()
+      # Starting at LLVM 9.0 filesystem is built in
+      set(FILESYSTEM_LIB)
     endif()
   else()
     set(FILESYSTEM_LIB stdc++fs)

--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_TESTING)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-      # Filesystem introduced to experimental in LLVM 7.0
+      # Before LLVM 7.0, filesystem is part of experimental
       set(FILESYSTEM_LIB c++experimental)
     elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
       # Before LLVM 9.0 you have to manually link the fs library

--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -53,6 +53,11 @@ namespace fs = std::filesystem;
 // MSVC deprecates <experimental/filesystem> and in favor of <filesystem>
 // use this macro to acknowledge this deprecation and unblock the build break
 #  define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+// Clang 9.0 deprecates experimental/filesystem in favor of C++17's
+// std::filesystem. Since pluginlib currently targets C++14 but needs to
+// support recent clang releases this acknowledges and suppresses the
+// deprecation error.
+#  define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
 #  include <experimental/filesystem>
 
 namespace pluginlib

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -31,6 +31,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=li
     # Starting at LLVM 9.0 filesystem is built in
     set(FILESYSTEM_LIB)
   endif()
+endif()
 
 if(UNIX AND NOT APPLE)
   # this is needed to use the experimental/filesystem on Linux, but cannot be passed with

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -31,6 +31,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=li
     # Starting at LLVM 9.0 filesystem is built in
     set(FILESYSTEM_LIB)
   endif()
+else()
+  set(FILESYSTEM_LIB stdc++fs)
 endif()
 
 if(UNIX AND NOT APPLE)

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -22,13 +22,15 @@ include("${pluginlib_DIR}/pluginlib_export_plugin_description_file.cmake")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+    # Before LLVM 7.0, filesystem is part of experimental
     set(FILESYSTEM_LIB c++experimental)
-  else()
+  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    # Before LLVM 9.0 you have to manually link the fs library
     set(FILESYSTEM_LIB c++fs)
+  else()
+    # Starting at LLVM 9.0 filesystem is built in
+    set(FILESYSTEM_LIB)
   endif()
-else()
-  set(FILESYSTEM_LIB stdc++fs)
-endif()
 
 if(UNIX AND NOT APPLE)
   # this is needed to use the experimental/filesystem on Linux, but cannot be passed with


### PR DESCRIPTION
The nightly Linux builds are now running on Focal which has LLVM 9, which no longer provides filesystem as a separate library and instead provides it as part of libc++

Intended to resolve red status on https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>