### PR TITLE
Bump to c++17

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(pluginlib)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+if(NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(NOT WIN32)

--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -37,7 +37,7 @@
 
 
 #if defined(__has_include)
-# if __has_include(<filesystem>) && __cplusplus >= 201703L
+# if __has_include(<filesystem>)
 #  include <filesystem>
 
 namespace pluginlib
@@ -50,14 +50,6 @@ namespace fs = std::filesystem;
 
 #  define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
 # elif __has_include(<experimental/filesystem>)
-// MSVC deprecates <experimental/filesystem> and in favor of <filesystem>
-// use this macro to acknowledge this deprecation and unblock the build break
-#  define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
-// Clang 9.0 deprecates experimental/filesystem in favor of C++17's
-// std::filesystem. Since pluginlib currently targets C++14 but needs to
-// support recent clang releases this acknowledges and suppresses the
-// deprecation error.
-#  define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
 #  include <experimental/filesystem>
 
 namespace pluginlib

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -20,6 +20,10 @@ ament_register_extension("ament_package" "pluginlib"
 
 include("${pluginlib_DIR}/pluginlib_export_plugin_description_file.cmake")
 
+if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
     # Before LLVM 7.0, filesystem is part of experimental


### PR DESCRIPTION
replaces #182

This allows us to use std::filesystem, as the logic in filesystem_helper sniffs the current c++ standard. CMake should fall back gracefully to c++14 if c++17 is not available.

This is a correct solution but not the best one, which would be add a library which wraps filesystem and which we link to instead of imposing compilation constraints on consuming projects