### PR TITLE
Using rcpputils for library names

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -14,10 +14,11 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(class_loader REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
-ament_export_dependencies(ament_index_cpp class_loader rcutils tinyxml2_vendor TinyXML2)
+ament_export_dependencies(ament_index_cpp class_loader rcutils rcpputils tinyxml2_vendor TinyXML2)
 ament_export_include_directories(include)
 
 install(
@@ -85,6 +86,7 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}_unique_ptr_test
       class_loader
       ament_index_cpp
+      rcpputils
       rcutils
       TinyXML2
     )
@@ -106,6 +108,7 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}_utest
       class_loader
       ament_index_cpp
+      rcpputils
       rcutils
       TinyXML2
     )

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -463,7 +463,7 @@ std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
         all_paths.push_back(current_search_path + path_separator + current_library_path);
       }
     }
-  } catch (const std::runtime_error& ex) {
+  } catch (const std::runtime_error & ex) {
     throw std::runtime_error{ex.what()};
   }
 

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -458,7 +458,6 @@ std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
       for (auto && current_library_path : all_relative_library_paths) {
         all_paths.push_back(current_search_path + path_separator + current_library_path);
       }
-      // We're in debug mode, try debug libraries as well
       for (auto && current_library_path : all_relative_debug_library_paths) {
         all_paths.push_back(current_search_path + path_separator + current_library_path);
       }

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -68,6 +68,7 @@
 #include "ament_index_cpp/get_resource.hpp"
 #include "ament_index_cpp/get_resources.hpp"
 #include "class_loader/class_loader.hpp"
+#include "rcpputils/shared_library.hpp"
 #include "rcutils/logging_macros.h"
 
 #include "./class_loader.hpp"
@@ -423,14 +424,6 @@ std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
     package_prefix + path_separator + "bin" + path_separator + exporting_package_name,
   };
 
-  // Prepare to setup the relative file paths.
-  bool debug_library_suffix = (0 == class_loader::systemLibrarySuffix().compare(0, 1, "d"));
-  std::string non_debug_suffix;
-  if (debug_library_suffix) {
-    non_debug_suffix = class_loader::systemLibrarySuffix().substr(1);
-  } else {
-    non_debug_suffix = class_loader::systemLibrarySuffix();
-  }
   std::string stripped_library_name = stripAllButFileFromPath(library_name);
 
   std::string library_name_alternative;  // either lib<library> or <library> without lib prefix
@@ -446,30 +439,32 @@ std::vector<std::string> ClassLoader<T>::getAllLibraryPathsToTry(
   }
   std::string stripped_library_name_alternative = stripAllButFileFromPath(library_name_alternative);
 
-  // Setup the relative file paths to pair with the search directories above.
-  std::vector<std::string> all_relative_library_paths = {
-    library_name + non_debug_suffix,
-    library_name_alternative + non_debug_suffix,
-    stripped_library_name + non_debug_suffix,
-    stripped_library_name_alternative + non_debug_suffix,
-  };
-  std::vector<std::string> all_relative_debug_library_paths = {
-    library_name + class_loader::systemLibrarySuffix(),
-    library_name_alternative + class_loader::systemLibrarySuffix(),
-    stripped_library_name + class_loader::systemLibrarySuffix(),
-    stripped_library_name_alternative + class_loader::systemLibrarySuffix(),
-  };
+  try {
+    // Setup the relative file paths to pair with the search directories above.
+    std::vector<std::string> all_relative_library_paths = {
+      rcpputils::get_platform_library_name(library_name),
+      rcpputils::get_platform_library_name(library_name_alternative),
+      rcpputils::get_platform_library_name(stripped_library_name),
+      rcpputils::get_platform_library_name(stripped_library_name_alternative)
+    };
+    std::vector<std::string> all_relative_debug_library_paths = {
+      rcpputils::get_platform_library_name(library_name, true),
+      rcpputils::get_platform_library_name(library_name_alternative, true),
+      rcpputils::get_platform_library_name(stripped_library_name, true),
+      rcpputils::get_platform_library_name(stripped_library_name_alternative, true)
+    };
 
-  for (auto && current_search_path : all_search_paths) {
-    for (auto && current_library_path : all_relative_library_paths) {
-      all_paths.push_back(current_search_path + path_separator + current_library_path);
-    }
-    // We're in debug mode, try debug libraries as well
-    if (debug_library_suffix) {
+    for (auto && current_search_path : all_search_paths) {
+      for (auto && current_library_path : all_relative_library_paths) {
+        all_paths.push_back(current_search_path + path_separator + current_library_path);
+      }
+      // We're in debug mode, try debug libraries as well
       for (auto && current_library_path : all_relative_debug_library_paths) {
         all_paths.push_back(current_search_path + path_separator + current_library_path);
       }
     }
+  } catch (const std::runtime_error& ex) {
+    throw std::runtime_error{ex.what()};
   }
 
   for (auto && path : all_paths) {

--- a/pluginlib/package.xml
+++ b/pluginlib/package.xml
@@ -24,6 +24,7 @@
   <depend>ament_index_cpp</depend>
   <depend>class_loader</depend>
   <depend>rcutils</depend>
+  <depend>rcpputils</depend>
   <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
I have seen this error on the buildfarm in PluginLib. Requesting for a missing reference `class_loader::systemLibrarySuffix` this function was removed from class_loader. Using rcpputils to get

```
(.text._ZN9pluginlib11ClassLoaderIN9test_base5FubarEE23getAllLibraryPathsToTryERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESB_[_ZN9pluginlib11ClassLoaderIN9test_base5FubarEE23getAllLibraryPathsToTryERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESB_]+0x415): undefined reference to `class_loader::systemLibrarySuffix[abi:cxx11]()'
21:35:03 /usr/bin/ld: unique_ptr_test.cpp:
```

Signed-off-by: ahcorde <ahcorde@gmail.com>