### PR TITLE
add missing export of stdc++fs and TinyXML2 via modern CMake

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -27,6 +27,28 @@ ament_export_dependencies(ament_index_cpp class_loader rcutils rcpputils tinyxml
 ament_export_include_directories(include)
 ament_export_targets(${PROJECT_NAME})
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+    # Before LLVM 7.0, filesystem is part of experimental
+    set(FILESYSTEM_LIB c++experimental)
+  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    # Before LLVM 9.0 you have to manually link the fs library
+    set(FILESYSTEM_LIB c++fs)
+  else()
+    # Starting at LLVM 9.0 filesystem is built in
+    set(FILESYSTEM_LIB)
+  endif()
+else()
+  set(FILESYSTEM_LIB stdc++fs)
+endif()
+
+if(UNIX AND NOT APPLE)
+  # this is needed to use the experimental/filesystem on Linux, but cannot be passed with
+  # ament_export_libraries() because it is not absolute and cannot be found with find_library
+  target_link_libraries(${PROJECT_NAME}
+    INTERFACE ${FILESYSTEM_LIB})
+endif()
+
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
 )

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -44,3 +44,10 @@ endif()
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 list(APPEND pluginlib_LIBRARIES ${TinyXML2_LIBRARIES})
+
+add_library(tinyxml2_vendor INTERFACE)
+target_include_directories(tinyxml2_vendor INTERFACE
+  ${TinyXML2_INCLUDE_DIRS})
+target_link_libraries(tinyxml2_vendor INTERFACE
+  ${TinyXML2_LIBRARIES})
+list(APPEND pluginlib_TARGETS tinyxml2_vendor)


### PR DESCRIPTION
Related to ros2/ros2#904.