### PR TITLE
link against tinyxml2 correctly

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -21,8 +21,9 @@ find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_ve
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   "$<INSTALL_INTERFACE:include>")
+target_link_libraries(${PROJECT_NAME} INTERFACE tinyxml2::tinyxml2)
 ament_target_dependencies(${PROJECT_NAME} INTERFACE
-  ament_index_cpp class_loader rcutils rcpputils tinyxml2_vendor TinyXML2)
+  ament_index_cpp class_loader rcutils rcpputils)
 ament_export_dependencies(ament_index_cpp class_loader rcutils rcpputils tinyxml2_vendor TinyXML2)
 ament_export_include_directories(include)
 ament_export_targets(${PROJECT_NAME})

--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -21,9 +21,8 @@ find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_ve
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   "$<INSTALL_INTERFACE:include>")
-target_link_libraries(${PROJECT_NAME} INTERFACE tinyxml2::tinyxml2)
 ament_target_dependencies(${PROJECT_NAME} INTERFACE
-  ament_index_cpp class_loader rcutils rcpputils)
+  ament_index_cpp class_loader rcutils rcpputils TinyXML2)
 ament_export_dependencies(ament_index_cpp class_loader rcutils rcpputils tinyxml2_vendor TinyXML2)
 ament_export_include_directories(include)
 ament_export_targets(${PROJECT_NAME})

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -40,14 +40,3 @@ if(UNIX AND NOT APPLE)
   # ament_export_libraries() because it is not absolute and cannot be found with find_library
   list(APPEND pluginlib_LIBRARIES ${FILESYSTEM_LIB})
 endif()
-
-find_package(tinyxml2_vendor REQUIRED)
-find_package(TinyXML2 REQUIRED)
-list(APPEND pluginlib_LIBRARIES ${TinyXML2_LIBRARIES})
-
-add_library(tinyxml2_vendor INTERFACE IMPORTED)
-target_include_directories(tinyxml2_vendor INTERFACE
-  ${TinyXML2_INCLUDE_DIRS})
-target_link_libraries(tinyxml2_vendor INTERFACE
-  ${TinyXML2_LIBRARIES})
-#list(APPEND pluginlib_TARGETS tinyxml2_vendor)

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -50,4 +50,4 @@ target_include_directories(tinyxml2_vendor INTERFACE
   ${TinyXML2_INCLUDE_DIRS})
 target_link_libraries(tinyxml2_vendor INTERFACE
   ${TinyXML2_LIBRARIES})
-list(APPEND pluginlib_TARGETS tinyxml2_vendor)
+#list(APPEND pluginlib_TARGETS tinyxml2_vendor)


### PR DESCRIPTION
closes #191 
Connects to ros2/rosbag2#402

I don't know exactly why but it looks to me as if `tinyxml2_vendor` as well as `TinyXML2` are not correctly linked to the interface target of pluginlib.

By explicitly linking to `tinyx2ml::tinyxml2` - and not adding the vendor package to the targets - the error message in https://github.com/ros2/rosbag2/pull/403#issuecomment-623623630 is being resolved.

As a general question, why should pluginlib export a dependency on the vendor package and not just directly transitively link to tinyxml2?