### PR TITLE
[ros2] Export tinyxml2 directly from pluginlib-extras.cmake

### DIFF
--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -45,4 +45,9 @@ find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 list(APPEND pluginlib_LIBRARIES ${TinyXML2_LIBRARIES})
 
-list(APPEND pluginlib_TARGETS tinyxml2)
+add_library(tinyxml2_vendor INTERFACE IMPORTED)
+target_include_directories(tinyxml2_vendor INTERFACE
+  ${TinyXML2_INCLUDE_DIRS})
+target_link_libraries(tinyxml2_vendor INTERFACE
+  ${TinyXML2_LIBRARIES})
+list(APPEND pluginlib_TARGETS tinyxml2_vendor)

--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -45,9 +45,4 @@ find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 list(APPEND pluginlib_LIBRARIES ${TinyXML2_LIBRARIES})
 
-add_library(tinyxml2_vendor INTERFACE)
-target_include_directories(tinyxml2_vendor INTERFACE
-  ${TinyXML2_INCLUDE_DIRS})
-target_link_libraries(tinyxml2_vendor INTERFACE
-  ${TinyXML2_LIBRARIES})
-list(APPEND pluginlib_TARGETS tinyxml2_vendor)
+list(APPEND pluginlib_TARGETS tinyxml2)


### PR DESCRIPTION
When I attempted to build `nav2_rviz_plugins`, I run into this CMake error:

```
CMake Error: install(EXPORT "nav2_rviz_plugins" ...) includes target "nav2_rviz_plugins" which requires target "tinyxml2_vendor" that is not in any export set.
CMake Generate step failed.  Build files cannot be regenerated correctly
```

After some digging, it is coming from this `pluginlib-extras.cmake`.

1. I either need to add `IMPORTED` to make `tinyxml2_vendor` as an interface imported library,
2. Or I need to directly define the `pluginlib_TARGETS` to be `tinyxml2` which is the target exported from `TinyXML2` project.