### PR TITLE
Don't export tinyxml2 internal details.

### DIFF
--- a/pluginlib/pluginlib-extras.cmake
+++ b/pluginlib/pluginlib-extras.cmake
@@ -44,10 +44,3 @@ endif()
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 list(APPEND pluginlib_LIBRARIES ${TinyXML2_LIBRARIES})
-
-add_library(tinyxml2_vendor INTERFACE IMPORTED)
-target_include_directories(tinyxml2_vendor INTERFACE
-  ${TinyXML2_INCLUDE_DIRS})
-target_link_libraries(tinyxml2_vendor INTERFACE
-  ${TinyXML2_LIBRARIES})
-list(APPEND pluginlib_TARGETS tinyxml2_vendor)


### PR DESCRIPTION
That should be done by tinyxml2 itself.  Also, this doesn't work
on earlier versions of cmake (3.10, in particular).

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Along with https://github.com/ros2/tinyxml2_vendor/pull/8, this is an alternative to #190.  This seems to fix the problems when building with rosbag2 (along with https://github.com/ros2/rosbag2/pull/403), and also seems to work for building the nav2_rviz_plugins that originally motivated #192.

@Karsten1987 FYI.