### PR TITLE
fix shebang line for python3

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -39,5 +39,5 @@ endif()
 install(DIRECTORY include/pluginlib/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-install(PROGRAMS scripts/pluginlib_headers_migration.py
+catkin_install_python(PROGRAMS scripts/pluginlib_headers_migration.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/pluginlib/scripts/pluginlib_headers_migration.py
+++ b/pluginlib/scripts/pluginlib_headers_migration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2018, Open Source Robotics Foundation, Inc.

--- a/pluginlib/scripts/pluginlib_headers_migration.py
+++ b/pluginlib/scripts/pluginlib_headers_migration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2018, Open Source Robotics Foundation, Inc.


### PR DESCRIPTION
Currently in Noetic/Focal the script cannot be run with rosrun:
```
/usr/bin/env: ‘python’: No such file or directory
```