### PR TITLE
Remove deprecated boost functions (fix build error on Rolling)

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -96,7 +96,6 @@ if(BUILD_TESTING)
   include_directories(include test/include)
 
   add_library(test_plugins SHARED ./test/test_plugins.cpp)
-  target_compile_definitions(test_plugins PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
   target_compile_definitions(test_plugins PRIVATE "TEST_PLUGINLIB_FIXTURE_BUILDING_LIBRARY")
   ament_target_dependencies(
     test_plugins
@@ -129,7 +128,6 @@ if(BUILD_TESTING)
       rcutils
       TinyXML2
     )
-    target_compile_definitions(${PROJECT_NAME}_unique_ptr_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
     if(UNIX AND NOT APPLE)
       target_link_libraries(${PROJECT_NAME}_unique_ptr_test ${FILESYSTEM_LIB})
@@ -151,7 +149,6 @@ if(BUILD_TESTING)
       rcutils
       TinyXML2
     )
-    target_compile_definitions(${PROJECT_NAME}_utest PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
     if(UNIX AND NOT APPLE)
       target_link_libraries(${PROJECT_NAME}_utest ${FILESYSTEM_LIB})

--- a/pluginlib/include/pluginlib/class_loader.hpp
+++ b/pluginlib/include/pluginlib/class_loader.hpp
@@ -51,10 +51,6 @@
 # include <memory>
 #endif
 
-#ifndef PLUGINLIB__DISABLE_BOOST_FUNCTIONS
-#include <boost/shared_ptr.hpp>
-#endif
-
 #include "class_loader/multi_library_class_loader.hpp"
 #include "pluginlib/class_desc.hpp"
 #include "pluginlib/class_loader_base.hpp"
@@ -123,16 +119,6 @@ public:
    * \return An instance of the class
    */
   std::shared_ptr<T> createSharedInstance(const std::string & lookup_name);
-#endif
-
-#ifndef PLUGINLIB__DISABLE_BOOST_FUNCTIONS
-  /// Create an instance of a desired class.
-  /**
-   * Deprecated, use createSharedInstance() instead.
-   * Same as createSharedInstance() except it returns a boost::shared_ptr.
-   */
-  [[deprecated]]
-  boost::shared_ptr<T> createInstance(const std::string & lookup_name);
 #endif
 
 #if defined(HAS_CPP11_MEMORY) && HAS_CPP11_MEMORY

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -169,41 +169,6 @@ std::shared_ptr<T> ClassLoader<T>::createSharedInstance(const std::string & look
 }
 #endif
 
-#ifndef PLUGINLIB__DISABLE_BOOST_FUNCTIONS
-template<class T>
-boost::shared_ptr<T> ClassLoader<T>::createInstance(const std::string & lookup_name)
-/***************************************************************************/
-{
-  RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-    "Attempting to create managed instance for class %s.",
-    lookup_name.c_str());
-
-  if (!isClassLoaded(lookup_name)) {
-    loadLibraryForClass(lookup_name);
-  }
-
-  try {
-    std::string class_type = getClassType(lookup_name);
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "%s maps to real class type %s",
-      lookup_name.c_str(), class_type.c_str());
-
-    boost::shared_ptr<T> obj = lowlevel_class_loader_.createInstance<T>(class_type);
-
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "boost::shared_ptr to object of real type %s created.",
-      class_type.c_str());
-
-    return obj;
-  } catch (const class_loader::CreateClassException & ex) {
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "Exception raised by low-level multi-library class loader when attempting "
-      "to create instance of class %s.",
-      lookup_name.c_str());
-    throw pluginlib::CreateClassException(ex.what());
-  }
-}
-#endif
-
 #if defined(HAS_CPP11_MEMORY) && HAS_CPP11_MEMORY
 template<class T>
 UniquePtr<T> ClassLoader<T>::createUniqueInstance(const std::string & lookup_name)


### PR DESCRIPTION
This PR Removes `PLUGINLIB__DISABLE_BOOST_FUNCTIONS` and the deprecated functions it wraps.
This should fix this downstream PR job failure in the `ros2/urdf` repo: http://build.ros2.org/job/Rpr__urdf__ubuntu_focal_amd64/4 .

```
--- stderr: urdf
In file included from /tmp/ws/src/urdf/urdf/src/model.cpp:39:
/opt/ros/rolling/include/pluginlib/class_loader.hpp:55:10: fatal error: boost/shared_ptr.hpp: No such file or directory
   55 | #include <boost/shared_ptr.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

The cause appears to be `PLUGINLIB__DISABLE_BOOST_FUNCTIONS` not being defined by default, meaning `class_loader.hpp` tries to include a boost header by default. However, pluginlib neither exports boost as a dependency in its CMakeLists.txt nor declares it in its package.xml. Since the deprecation appears to have been added in 2017 I think it's fair to remove it.

https://github.com/ros/pluginlib/commit/244f065db2f110b15ec19b6ec797d28ea455d973#diff-ca2b6071ef290a8731c40a238f8e40a8R41