### PR TITLE
cmake 3.5 compatibility

### DIFF
--- a/pluginlib/cmake/pluginlib_enable_plugin_testing.cmake
+++ b/pluginlib/cmake/pluginlib_enable_plugin_testing.cmake
@@ -166,9 +166,9 @@ function(pluginlib_enable_plugin_testing)
   list(APPEND output_files "${prefix}/share/ament_index/resource_index/${ARG_PLUGIN_CATEGORY}__pluginlib__plugin/${ARG_PACKAGE_NAME}")
 
   # Get rid of FOOBAR
-  list(POP_FRONT input_files)
-  list(POP_FRONT input_content)
-  list(POP_FRONT output_files)
+  list(REMOVE_AT input_files 0)
+  list(REMOVE_AT input_content 0)
+  list(REMOVE_AT output_files 0)
 
   #####
   # Create commands to generate mock install space at build time


### PR DESCRIPTION
addresses comment [here](https://github.com/ros/pluginlib/pull/201/files#r477957667) where `POP_FRONT` introduces a dependency to cmake 3.15. This is not available on ubuntu 18.04 which would make it tricky to compile Foxy or ros2 from source.

cmake's `REMOVE_AT` should actually do the same thing.