### PR TITLE
do not use experimental on clang>=10

### DIFF
--- a/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+++ b/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
@@ -49,7 +49,7 @@ namespace fs = std::filesystem;
 }  // namespace pluginlib
 
 #  define PLUGINLIB__IMPL__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-# elif __has_include(<experimental/filesystem>)
+# elif __has_include(<experimental/filesystem>) && __clang_major__ < 10
 // MSVC deprecates <experimental/filesystem> and in favor of <filesystem>
 // use this macro to acknowledge this deprecation and unblock the build break
 #  define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING


### PR DESCRIPTION
I could not get pluginlib to compile with a homebrew llvm clang. Note this is different of AppleClang which is shipped by default on OSX. The filesystem libraries are marked explicitly unavailable until OSX 10.15.
That's the same problem as described here: https://answers.ros.org/question/338832/ros2-source-install-macos-10151-qt_gui_cpp-fails/

Don't have much more info about this though. Some information might be here:
https://stackoverflow.com/questions/42633477/macos-clang-c17-filesystem-header-not-found

Might be related to https://github.com/ros/pluginlib/issues/168 

As a general question, I am wondering though why we ship pluginlib with this custom logic. It anyways depends on `rcpputils` already, why not using their filesystem implementation?