### PR TITLE
avoid infinite loop if package.xml is not found

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -597,11 +597,13 @@ ClassLoader<T>::getPackageFromPluginXMLFilePath(const std::string & plugin_xml_f
       return extractPackageNameFromPackageXML(package_file_path);
     }
 
-    // Recursive case - hop one folder up
+    // Recursive case - hop one folder up and store current parent
+    // parent_path() returns the current path if we reached the root.
+    p = parent;
     parent = parent.parent_path();
 
     // Base case - reached root and cannot find what we're looking for
-    if (parent.string().empty()) {
+    if (parent.string().empty() || (p == parent)) {
       return "";
     }
   }


### PR DESCRIPTION
The code in `getPackageFromPluginXMLFilePath` currently never exits from the while loop if the `package.xml` file is not found.
The reason is that the code assumes that `parent_path()` will eventually return an empty path, but this is not the case.
See source code for the function: https://github.com/ros2/rcpputils/blob/master/src/filesystem_helper.cpp#L172-L182

In the situation where the file is not found, the while loop will eventually reach the root of the filesystem and `parent_path` will continuously return the root itself.

This PR adds a check to make sure that we exit from the function if the path returned from `parent_path` is equal to the previous one.


Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>