### PR TITLE
Missing dependency on libboost-thread

### DIFF
--- a/pluginlib/package.xml
+++ b/pluginlib/package.xml
@@ -23,8 +23,9 @@
 
   <depend>ament_index_cpp</depend>
   <depend>class_loader</depend>
-  <depend>rcutils</depend>
+  <depend>libboost-thread</depend>
   <depend>rcpputils</depend>
+  <depend>rcutils</depend>
   <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
Our CI failed because boost didn't get installed.

Targetting foxy branch as it doesn't affact galactic.