### PR TITLE
Install includes to include/${PROJECT_NAME} and remove ament_target_dependencies calls.

### DIFF
--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -79,6 +79,8 @@ if(BUILD_TESTING)
     APPEND_ENV AMENT_PREFIX_PATH=${mock_install_path}
   )
   if(TARGET ${PROJECT_NAME}_utest)
+    # Used, but not linked to test ${PROJECT_NAME}'s exports:
+    #   rcutils::rcutils
     target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
     add_dependencies(${PROJECT_NAME}_utest "${mock_install_target}")
   endif()

--- a/pluginlib/CMakeLists.txt
+++ b/pluginlib/CMakeLists.txt
@@ -20,15 +20,21 @@ find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_ve
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
-  "$<INSTALL_INTERFACE:include>")
-ament_target_dependencies(${PROJECT_NAME} INTERFACE
-  ament_index_cpp class_loader rcutils rcpputils TinyXML2)
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  ament_index_cpp::ament_index_cpp
+  class_loader::class_loader
+  rcutils::rcutils
+  rcpputils::rcpputils
+  tinyxml2::tinyxml2)
+
 ament_export_dependencies(ament_index_cpp class_loader rcutils rcpputils tinyxml2_vendor TinyXML2)
-ament_export_include_directories(include)
-ament_export_targets(${PROJECT_NAME})
+
+ament_export_targets(export_${PROJECT_NAME})
 
 install(
-  TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
 )
 
 install(
@@ -36,10 +42,7 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -48,10 +51,7 @@ if(BUILD_TESTING)
 
   add_library(test_plugins SHARED ./test/test_plugins.cpp)
   target_compile_definitions(test_plugins PRIVATE "TEST_PLUGINLIB_FIXTURE_BUILDING_LIBRARY")
-  ament_target_dependencies(
-    test_plugins
-    class_loader
-  )
+  target_link_libraries(test_plugins ${PROJECT_NAME})
 
   include("cmake/pluginlib_enable_plugin_testing.cmake")
   pluginlib_enable_plugin_testing(
@@ -70,15 +70,7 @@ if(BUILD_TESTING)
     APPEND_ENV AMENT_PREFIX_PATH=${mock_install_path}
   )
   if(TARGET ${PROJECT_NAME}_unique_ptr_test)
-    ament_target_dependencies(
-      ${PROJECT_NAME}_unique_ptr_test
-      class_loader
-      ament_index_cpp
-      rcpputils
-      rcutils
-      TinyXML2
-    )
-
+    target_link_libraries(${PROJECT_NAME}_unique_ptr_test ${PROJECT_NAME})
     add_dependencies(${PROJECT_NAME}_unique_ptr_test "${mock_install_target}")
   endif()
 
@@ -87,15 +79,7 @@ if(BUILD_TESTING)
     APPEND_ENV AMENT_PREFIX_PATH=${mock_install_path}
   )
   if(TARGET ${PROJECT_NAME}_utest)
-    ament_target_dependencies(
-      ${PROJECT_NAME}_utest
-      class_loader
-      ament_index_cpp
-      rcpputils
-      rcutils
-      TinyXML2
-    )
-
+    target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
     add_dependencies(${PROJECT_NAME}_utest "${mock_install_target}")
   endif()
 


### PR DESCRIPTION
Part of ament/ament_cmake#365
Part of ament/ament_cmake#292
Part of ros2/ros2#1150

This makes pluginlib install includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages, and it also replaces `ament_target_dependencies()` with `target_link_libraries()`

