### PR TITLE
Documented possible exception being thrown in ClassLoader destructor.

### DIFF
--- a/pluginlib/include/pluginlib/class_loader.hpp
+++ b/pluginlib/include/pluginlib/class_loader.hpp
@@ -77,7 +77,11 @@ public:
     std::string attrib_name = std::string("plugin"),
     std::vector<std::string> plugin_xml_paths = std::vector<std::string>());
 
-  ~ClassLoader();
+  /// The destructor attempts to unload all libraries which are still loaded.
+  /**
+   * \throws class_loader::LibraryUnloadException if unloading a library fails
+   */
+  ~ClassLoader() override;
 
   /// Create an instance of a desired class, optionally loading the associated library too.
   /**


### PR DESCRIPTION
The class member `class_loader::MultiLibraryClassLoader lowlevel_class_loader_` can throw an exception when being destroyed (which actually happened to me). This can be hard to fix, especially if one defines the `ClassLoader` instance to be `static`. In this case the instance is destroyed when the executable exits where you can't catch exceptions.

Documenting this behavior should help others to be careful. Also it is consistent with the documentation of the other methods.