### PR TITLE
Expose on-demand library load/unload in class loader constructor.

### DIFF
--- a/pluginlib/include/pluginlib/class_loader.hpp
+++ b/pluginlib/include/pluginlib/class_loader.hpp
@@ -70,12 +70,15 @@ public:
    * \param attrib_name The attribute to search for in manifext.xml files, defaults to "plugin"
    * \param plugin_xml_paths The list of paths of plugin.xml files, defaults to be crawled via
    *   ros::package::getPlugins()
+   * \param enable_ondemand_loadunload Set this argument to true to enable automatic library
+   *   loading/unloading
    * \throws pluginlib::ClassLoaderException if package manifest cannot be found
    */
   ClassLoader(
     std::string package, std::string base_class,
     std::string attrib_name = std::string("plugin"),
-    std::vector<std::string> plugin_xml_paths = std::vector<std::string>());
+    std::vector<std::string> plugin_xml_paths = std::vector<std::string>(),
+    bool enable_ondemand_loadunload = false);
 
   ~ClassLoader();
 

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -68,16 +68,12 @@ namespace pluginlib
 template<class T>
 ClassLoader<T>::ClassLoader(
   std::string package, std::string base_class, std::string attrib_name,
-  std::vector<std::string> plugin_xml_paths)
+  std::vector<std::string> plugin_xml_paths, bool enable_ondemand_loadunload)
 : plugin_xml_paths_(plugin_xml_paths),
   package_(package),
   base_class_(base_class),
   attrib_name_(attrib_name),
-  // NOTE: The parameter to the class loader enables/disables on-demand class
-  // loading/unloading.
-  // Leaving it off for now... libraries will be loaded immediately and won't
-  // be unloaded until class loader is destroyed or force unload.
-  lowlevel_class_loader_(false)
+  lowlevel_class_loader_(enable_ondemand_loadunload)
   /***************************************************************************/
 {
   ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Creating ClassLoader, base = %s, address = %p",


### PR DESCRIPTION
Currently, on-demand library loading/unloading is hard-coded to `false`. This leads to the fact that libraries are unloaded on destruction of the `ClassLoader` instance, which can throw exceptions (see https://github.com/ros/pluginlib/pull/234).

In my use case I'd like to unload the libraries on-demand, so I do not have to deal with exceptions when the destructor of the `ClassLoader` instance is called.

This PR exposes the setting in the `ClassLoader` constructor. The default value is `false` for backwards compatibility.