### PR TITLE
Use `ifdef` instead of `if` for win32

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -319,7 +319,7 @@ std::vector<std::string> ClassLoader<T>::getCatkinLibraryPaths()
     boost::split(catkin_prefix_paths, env_catkin_prefix_paths, boost::is_any_of(os_pathsep));
     BOOST_FOREACH(std::string catkin_prefix_path, catkin_prefix_paths) {
       boost::filesystem::path path(catkin_prefix_path);
-#if _WIN32
+#ifdef _WIN32
       boost::filesystem::path bin("bin");
       lib_paths.push_back((path / bin).string());
 #endif


### PR DESCRIPTION
Fixes the following error
```
 /opt/ros/noetic/include/pluginlib/./class_loader_imp.hpp:322:5: error: "_WIN32" is not defined, evaluates to 0 [-Werror=undef]
    322 | #if _WIN32
        |     ^~~~~~
  cc1plus: all warnings being treated as errors
  ```
  
  In other spots in the same file `ifdef` is used instead of `if`. Outside of this file no win32 check is done.