### PR TITLE
Avoid throwing on symlink loops.

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -436,10 +436,13 @@ std::string ClassLoader<T>::getClassLibraryPath(const std::string & lookup_name)
     it++)
   {
     ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Checking path %s ", it->c_str());
-    if (boost::filesystem::exists(*it)) {
-      ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Library %s found at explicit path %s.",
-        library_name.c_str(), it->c_str());
-      return *it;
+    boost::system::error_code error_code; // pass an error code to avoid throwing.
+    if (boost::filesystem::exists(*it, error_code)) {
+      if (error_code.value() == boost::system::errc::success) {
+        ROS_DEBUG_NAMED("pluginlib.ClassLoader", "Library %s found at explicit path %s.",
+          library_name.c_str(), it->c_str());
+        return *it;
+      }
     }
   }
   return "";


### PR DESCRIPTION
Hi, we were seeing a throw from rviz with the following message:
```
terminate called after throwing an instance of 'boost::filesystem::filesystem_error'
  what():  boost::filesystem::status: Too many levels of symbolic links: "/nix/store/44kcmy9bsw44y13bf7x5kzlm9s4cdhpr-libgccjit-10.3.0/lib/lib/libcpr_viz.so"
Aborted
```
Here, the `/nix/store/44kcmy9bsw44y13bf7x5kzlm9s4cdhpr-libgccjit-10.3.0/lib/` directory is a symlink to itself, so there's an endless recursion. The `boost::filesystem::exists` method throws in this instance, but the exception is not caught anywhere, so rviz exits.

Instead, it is safer to use the overload that takes the error code and ensure that the function returned success, I don't think pluginlib should ever result in an uncaught throw?

fyi @mikepurvis, @jasonimercer, @nlunscher-cpr (CORE-23076)