### PR TITLE
Fix wShadow compile warning

### DIFF
--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -488,12 +488,12 @@ std::string ClassLoader<T>::getClassLibraryPath(const std::string & lookup_name)
   RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
     "Iterating through all possible paths where %s could be located...",
     library_name.c_str());
-  for (auto it = paths_to_try.begin(); it != paths_to_try.end(); it++) {
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "Checking path %s ", it->c_str());
-    if (rcpputils::fs::exists(*it)) {
+  for (auto path_it = paths_to_try.begin(); path_it != paths_to_try.end(); path_it++) {
+    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "Checking path %s ", path_it->c_str());
+    if (rcpputils::fs::exists(*path_it)) {
       RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader", "Library %s found at explicit path %s.",
-        library_name.c_str(), it->c_str());
-      return *it;
+        library_name.c_str(), path_it->c_str());
+      return *path_it;
     }
   }
   std::ostringstream error_msg;


### PR DESCRIPTION
`it` is defined on L479 and then again in the for loop. Renamed the for look items so that it doesn't compile with warnings turned to errors with `-wshadow` enabled 