### PR TITLE
Removed deprecated method

### DIFF
--- a/pluginlib/include/pluginlib/class_loader.hpp
+++ b/pluginlib/include/pluginlib/class_loader.hpp
@@ -71,22 +71,6 @@ public:
 
   ~ClassLoader();
 
-  /// Create an instance of a desired class, optionally loading the associated library too.
-  /**
-   * \param lookup_name The name of the class to load
-   * \param auto_load Specifies whether or not to automatically load the
-   *   library containing the class, set to true by default.
-   * \throws pluginlib::LibraryLoadException when the library associated
-   *   with the class cannot be loaded
-   * \throws pluginlib::CreateClassException when the class cannot be instantiated
-   * \return An instance of the class
-   * \deprecated use either createInstance() or createUnmanagedInstance()
-   */
-  [[deprecated]]
-  T * createClassInstance(
-    const std::string & lookup_name,
-    bool auto_load = true);
-
   /// Create an instance of a desired class.
   /**
    * Implicitly calls loadLibraryForClass() to increment the library counter.

--- a/pluginlib/include/pluginlib/class_loader_base.hpp
+++ b/pluginlib/include/pluginlib/class_loader_base.hpp
@@ -39,8 +39,7 @@ namespace pluginlib
 /**
  * This allows the writing of non-templated manager code
  * which can call all the administrative functions of ClassLoaders -
- * everything except createClassInstance(), createInstance()
- * and createUnmanagedInstance().
+ * everything except createInstance() and createUnmanagedInstance().
  */
 class ClassLoaderBase
 {

--- a/pluginlib/include/pluginlib/class_loader_imp.hpp
+++ b/pluginlib/include/pluginlib/class_loader_imp.hpp
@@ -112,38 +112,6 @@ ClassLoader<T>::~ClassLoader()
     getBaseClassType().c_str(), static_cast<void *>(this));
 }
 
-
-template<class T>
-T * ClassLoader<T>::createClassInstance(const std::string & lookup_name, bool auto_load)
-/***************************************************************************/
-{
-  // Note: This method is deprecated
-  RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-    "In deprecated call createClassInstance(), lookup_name = %s, auto_load = %i.",
-    (lookup_name.c_str()), auto_load);
-
-  if (auto_load && !isClassLoaded(lookup_name)) {
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "Autoloading class library before attempting to create instance.");
-    loadLibraryForClass(lookup_name);
-  }
-
-  try {
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "Attempting to create instance through low-level MultiLibraryClassLoader...");
-    T * obj = lowlevel_class_loader_.createUnmanagedInstance<T>(getClassType(lookup_name));
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "Instance created with object pointer = %p", static_cast<void *>(obj));
-
-    return obj;
-  } catch (const class_loader::CreateClassException & ex) {
-    RCUTILS_LOG_DEBUG_NAMED("pluginlib.ClassLoader",
-      "CreateClassException about to be raised for class %s",
-      lookup_name.c_str());
-    throw pluginlib::CreateClassException(ex.what());
-  }
-}
-
 template<class T>
 std::shared_ptr<T> ClassLoader<T>::createSharedInstance(const std::string & lookup_name)
 /***************************************************************************/


### PR DESCRIPTION
This method was deprecated at least since `humble` https://github.com/ros/pluginlib/blob/humble/pluginlib/include/pluginlib/class_loader.hpp#L85-L88. It should be fine to remove this on `rolling`.