### PR TITLE
Fixed test_pluginlib maintainer and license

### DIFF
--- a/pluginlib/test/test_package.xml
+++ b/pluginlib/test/test_package.xml
@@ -6,6 +6,8 @@
   <description>
     This tests pluginlib.
   </description>
+  <maintainer email="clalancette@gmail.com">Chris Lalancette</maintainer>
+  <license>BSD</license>
   <export>
     <pluginlib plugin="${prefix}/test_plugins.xml" />
   </export>


### PR DESCRIPTION
Related with https://github.com/ros/pluginlib/issues/219

This issue was solved by @clalancette from `kilted` in this PR https://github.com/ros/pluginlib/pull/265 but in `jazzy` and `humble` is still present