### PR TITLE
Add dependency on ros2plugin in package.xml

### DIFF
--- a/pluginlib/package.xml
+++ b/pluginlib/package.xml
@@ -29,6 +29,8 @@
   <depend>rcpputils</depend>
   <depend>tinyxml2</depend>
 
+  <exec_depend>ros2plugin</exec_depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Hi, I think we need to add the dependency here so it is automatically installed when installing pluginlib