### PR TITLE
Improve logging when unable to parse the plugin

### DIFF
--- a/ros2plugin/ros2plugin/verb/list.py
+++ b/ros2plugin/ros2plugin/verb/list.py
@@ -65,8 +65,13 @@ class ListVerb(VerbExtension):
                 plugin_xml = os.path.join(package_prefix, package_plugin_resource)
                 if not os.path.isfile(plugin_xml):
                     print('XML manifest ' + os.path.basename(plugin_xml) + ' not found.')
-
-                tree = ET.parse(plugin_xml)
+                try:
+                    tree = ET.parse(plugin_xml)
+                except ET.ParseError as e:
+                    print(
+                        f'Failed to parse plugin XML file: {plugin_xml}\n'
+                        f'XML error: {e}'
+                    )
 
                 for e in tree.iter():
                     if e.tag == 'class':


### PR DESCRIPTION
I have encountered cases like https://github.com/moveit/moveit2/pull/3599, where invalid XML syntax causes `ros2 plugin list` to hang and output errors like:

```
moveit_kinematics:
Traceback (most recent call last):
  File "/opt/ros/rolling/bin/ros2", line 33, in <module>
    sys.exit(load_entry_point('ros2cli==0.40.1', 'console_scripts', 'ros2')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ros/rolling/lib/python3.12/site-packages/ros2cli/cli.py", line 91, in main
    rc = extension.main(parser=parser, args=args)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ros/rolling/lib/python3.12/site-packages/ros2plugin/command/plugin.py", line 37, in main
    return extension.main(args=args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ros/rolling/lib/python3.12/site-packages/ros2plugin/verb/list.py", line 68, in main
    tree = ET.parse(plugin_xml)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/xml/etree/ElementTree.py", line 1204, in parse
    tree.parse(source, parser)
  File "/usr/lib/python3.12/xml/etree/ElementTree.py", line 569, in parse
    self._root = parser._parse_whole(source)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 2, column 129
```

This PR makes the error easier to understand and unblock the rest of the packages

```
Failed to parse plugin XML file: /root/moveit_ws/install/moveit_kinematics/share/moveit_kinematics/cached_ik_kinematics_plugin_description.xml
XML error: not well-formed (invalid token): line 2, column 129
```